### PR TITLE
feat: node 서버 db 연결 방식 변경 (Transaction pooler -> Direct)

### DIFF
--- a/src/modules/supabase/supabase.module.ts
+++ b/src/modules/supabase/supabase.module.ts
@@ -18,8 +18,14 @@ import { addTransactionalDataSource } from 'typeorm-transactional';
         database: configService.get('DB_DATABASE'),
         synchronize: false,
         entities: [path.join(__dirname, '../**/*.entity{.ts,.js}')],
-        logging: true,
+        logging: process.env.NODE_ENV === 'development',
         timezone: 'local',
+        poolSize: process.env.NODE_ENV === 'production' ? 5 : 1, // 풀 사이즈 조절
+        extra: {
+          max: 20, // 최대 연결 수
+          idleTimeoutMillis: 30000, // 유휴 연결 타임아웃
+          connectionTimeoutMillis: 2000, // 연결 타임아웃
+        },
       }),
       async dataSourceFactory(option) {
         if (!option) throw new Error('Invalid options passed');


### PR DESCRIPTION
# Supabase 연결 방식 변경 (Transaction pooler -> Direct)

## 변경 사항
- 데이터베이스 연결 방식을 Transaction pooler에서 Direct 연결 방식으로 변경

## 변경 이유
1. 현재 Transaction pooler를 사용하고 있어 불필요한 연결 오버헤드 발생
2. Direct 연결 방식으로 변경하여 연결 성능 개선
3. 연결 풀 관리로 인한 리소스 사용 최소화