### PR TITLE
[Feat] 학과 공지사항 조회 API 추가

### DIFF
--- a/src/api/public/message-templates/common-messages.service.ts
+++ b/src/api/public/message-templates/common-messages.service.ts
@@ -1,12 +1,39 @@
 import { Injectable } from '@nestjs/common';
+import { TextCard } from 'src/api/common/interfaces/response/fields/component';
+import { Button } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { createSimpleText } from 'src/api/common/utils/component';
+import { createSimpleText, createTextCard } from 'src/api/common/utils/component';
+import { BlockId } from 'src/api/common/utils/constants';
 
 @Injectable()
 export class CommonMessagesService {
   createSimpleText(text: string): SkillTemplate {
     return {
       outputs: [createSimpleText(text)],
+    };
+  }
+
+  /**
+   * 학과 인증 필요 메시지 생성
+   * @returns SkillTemplate (TextCard with button)
+   */
+  createDepartmentAuthRequiredMessage(): SkillTemplate {
+    const buttons: Button[] = [
+      {
+        label: '학과 등록',
+        action: 'block',
+        blockId: BlockId.CHANGE_PROFILE,
+      },
+    ];
+
+    const textCard: TextCard = createTextCard(
+      '잠깐! 학과 인증이 필요한 서비스야!\n아래 버튼을 눌러 학과를 등록해줘!',
+      undefined,
+      buttons,
+    );
+
+    return {
+      outputs: [textCard],
     };
   }
 }

--- a/src/api/public/message-templates/notice-messages.service.ts
+++ b/src/api/public/message-templates/notice-messages.service.ts
@@ -53,7 +53,66 @@ export class NoticeMessagesService {
   }
 
   /**
-   * 공지사항 URL 생성
+   * 학과 공지사항 캐러셀 생성
+   * @param noticesByCategory 카테고리별 공지사항 Map (department relation 포함)
+   * @returns SkillTemplate (캐러셀 형태의 여러 ListCard)
+   */
+  createDepartmentNoticeCarousel(
+    noticesByCategory: Map<NoticeCategory, Notice[]>,
+  ): SkillTemplate {
+    const carouselItems: ListCard['listCard'][] = [];
+
+    for (const [category, notices] of noticesByCategory) {
+      const header: ListItem = {
+        title: `${category.department.name} - ${category.category}`,
+      };
+
+      const items: ListItem[] = notices.map((notice) => ({
+        title: notice.title,
+        description: this.formatNoticeDate(notice.createdAt),
+        link: {
+          web: this.createDepartmentNoticeLinkUrl(
+            category.department.departmentEn,
+            category.mi,
+            category.bbsId,
+            notice.nttSn,
+          ),
+        },
+      }));
+
+      const buttons = [
+        {
+          label: '더보기',
+          action: 'webLink' as const,
+          webLinkUrl: this.createNoticeBoardListUrl(
+            category.department.departmentEn,
+            category.mi,
+            category.bbsId,
+          ),
+        },
+      ];
+
+      carouselItems.push({
+        header,
+        items,
+        buttons,
+      });
+    }
+
+    const carousel: Carousel = {
+      carousel: {
+        type: 'listCard',
+        items: carouselItems,
+      },
+    };
+
+    return {
+      outputs: [carousel],
+    };
+  }
+
+  /**
+   * 공지사항 URL 생성 (학교용)
    * @param mi notice_category.mi
    * @param bbsId notice_category.bbs_id
    * @param nttSn notice.ntt_sn
@@ -61,6 +120,38 @@ export class NoticeMessagesService {
    */
   private createNoticeLinkUrl(mi: number, bbsId: number, nttSn: number): string {
     return `https://www.gnu.ac.kr/main/na/ntt/selectNttInfo.do?mi=${mi}&bbsId=${bbsId}&nttSn=${nttSn}`;
+  }
+
+  /**
+   * 공지사항 URL 생성 (학과용)
+   * @param departmentEn department.department_en
+   * @param mi notice_category.mi
+   * @param bbsId notice_category.bbs_id
+   * @param nttSn notice.ntt_sn
+   * @returns 공지사항 URL
+   */
+  private createDepartmentNoticeLinkUrl(
+    departmentEn: string,
+    mi: number,
+    bbsId: number,
+    nttSn: number,
+  ): string {
+    return `https://www.gnu.ac.kr/${departmentEn}/na/ntt/selectNttInfo.do?mi=${mi}&bbsId=${bbsId}&nttSn=${nttSn}`;
+  }
+
+  /**
+   * 공지사항 게시판 목록 URL 생성
+   * @param departmentEn department.department_en
+   * @param mi notice_category.mi
+   * @param bbsId notice_category.bbs_id
+   * @returns 공지사항 게시판 목록 URL
+   */
+  private createNoticeBoardListUrl(
+    departmentEn: string,
+    mi: number,
+    bbsId: number,
+  ): string {
+    return `https://www.gnu.ac.kr/${departmentEn}/na/ntt/selectNttList.do?mi=${mi}&bbsId=${bbsId}`;
   }
 
   /**

--- a/src/api/public/notices/dtos/requests/list-department-notice-request.dto.ts
+++ b/src/api/public/notices/dtos/requests/list-department-notice-request.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ClientExtraDto } from 'src/api/common/dtos/requests';
+
+export class ListDepartmentNoticeRequestDto extends ClientExtraDto {
+  @ApiProperty({
+    description: '학과 공지사항 조회',
+    default: {},
+  })
+  extra?: Record<string, any>;
+}

--- a/src/api/public/notices/notices.controller.ts
+++ b/src/api/public/notices/notices.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator';
-import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
+import { CurrentUser } from 'src/api/public/users/decorators/current-user.decorator';
+import { User } from 'src/type-orm/entities/users/users.entity';
+import { ListDepartmentNoticeRequestDto } from './dtos/requests/list-department-notice-request.dto';
 import { ListUniversityNoticeRequestDto } from './dtos/requests/list-university-notice-request.dto';
 import { NoticesService } from './notices.service';
 
@@ -15,6 +17,13 @@ export class NoticesController {
   @ApiSkillBody(ListUniversityNoticeRequestDto)
   async listUniversityNotices() {
     const template = await this.noticesService.getUniversityNoticeTemplate();
+    return new ResponseDTO(template);
+  }
+
+  @Post('department')
+  @ApiSkillBody(ListDepartmentNoticeRequestDto)
+  async listDepartmentNotices(@CurrentUser() user: User) {
+    const template = await this.noticesService.getDepartmentNoticeTemplate(user);
     return new ResponseDTO(template);
   }
 }

--- a/src/type-orm/entities/departments/department.entity.ts
+++ b/src/type-orm/entities/departments/department.entity.ts
@@ -17,10 +17,20 @@ export class Department {
   @Column({ name: 'department_ko' })
   name: string;
 
+  @Column({ name: 'department_en' })
+  departmentEn: string;
+
+  @Column({ name: 'parent_department_id', nullable: true })
+  parentDepartmentId: number;
+
   @OneToMany(() => User, (users) => users.department)
   users: User[];
 
   @ManyToOne(() => College, (college) => college.departments)
   @JoinColumn({ name: 'college_id' })
   college: College;
+
+  @ManyToOne(() => Department)
+  @JoinColumn({ name: 'parent_department_id' })
+  parentDepartment: Department;
 }

--- a/src/type-orm/entities/notices/notice-categories.repository.ts
+++ b/src/type-orm/entities/notices/notice-categories.repository.ts
@@ -60,4 +60,19 @@ export class NoticeCategoriesRepository {
       .andWhere('category.category IN (:...categoryNames)', { categoryNames })
       .getMany();
   }
+
+  /**
+   * 여러 학과의 모든 카테고리 조회
+   * @param departmentIds 학과 ID 배열
+   * @returns 카테고리 목록 (department relation 포함)
+   */
+  findByDepartmentIds(departmentIds: number[]): Promise<NoticeCategory[]> {
+    return this.noticeCategoryRepository
+      .createQueryBuilder('category')
+      .leftJoinAndSelect('category.department', 'department')
+      .where('category.department_id IN (:...departmentIds)', { departmentIds })
+      .orderBy('category.department_id', 'ASC')
+      .addOrderBy('category.category', 'ASC')
+      .getMany();
+  }
 }


### PR DESCRIPTION
- close #24

<img width="743" height="471" alt="image" src="https://github.com/user-attachments/assets/3cef0278-3646-4db3-b700-3d0ab59caa94" />

## 📝 기능 설명

사용자의 학과 정보를 기반으로 **학과 공지사항 조회 API**를 추가했습니다.  
학과 인증이 필요한 경우 등록 플로우로 유도하며, **상위 학과(parent department)** 가 존재하면 해당 공지사항도 함께 조회합니다.

- **Endpoint:** `POST /api/node/notices/department`
- 카카오 챗봇 **ListCard 캐로셀** 형태로 응답
- "더보기" 버튼을 통해 학과 게시판 전체 목록으로 이동 가능

---

## 🛠 작업 사항

### 1️⃣ 학과 계층 구조 확장
- `Department` 엔티티에 `departmentEn`, `parentDepartmentId`, `parentDepartment` 관계 추가

### 2️⃣ 학과 공지 조회 로직 구현
- `NoticesService.getDepartmentNoticeTemplate()`
  - 학과 인증 여부 검증
  - 본인 학과 + 상위 학과 ID 수집
  - 카테고리별 최신 공지 조회
  - 예외 케이스 처리 (인증 없음 / 게시판 없음 / 글 없음)

### 3️⃣ 메시지 템플릿 확장
- 학과 공지 캐로셀 생성
- 학과 공지 URL 생성 로직 추가 (`/{departmentEn}/...`)
- "더보기" 버튼 추가 (게시판 목록 이동)
- 학과 미등록 사용자 안내 TextCard 메시지 추가

### 4️⃣ Repository / DTO / Controller
- `findByDepartmentIds()` 구현
- `ListDepartmentNoticeRequestDto` 추가
- `POST /department` 엔드포인트 추가

---

## ✅ 작업 체크리스트

- [x] 학과 인증 기반 공지 조회 동작
- [x] 상위 학과 공지 자동 포함
- [x] 캐로셀 응답 정상 생성
- [x] 예외 케이스 처리 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학과별 공지사항 조회 기능 추가: 사용자가 소속 학과의 공지사항을 카테고리별로 확인할 수 있습니다.
  * 학과 인증 필수 메시지 추가: 학과 등록이 필요한 경우 안내 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->