### PR TITLE
[Refactor] Native App 지원을 위한 서비스 레이어 카카오 종속성 제거

### DIFF
--- a/services/api/app/src/api/internal/warmup/warmup.service.ts
+++ b/services/api/app/src/api/internal/warmup/warmup.service.ts
@@ -102,7 +102,7 @@ export class WarmupService implements OnApplicationBootstrap {
       const cafeterias = await this.cafeteriasRepository.findCafeteriasByCampusId();
       await Promise.allSettled(
         cafeterias.map((cafeteria) =>
-          this.cafeteriasService.getCafeteriaDietTemplate(cafeteria.id),
+          this.cafeteriasService.getCafeteriaDiet(cafeteria.id),
         ),
       );
       this.logger.log(`diet cache prewarmed — count=${cafeterias.length}`);

--- a/services/api/app/src/api/public/cafeterias/cafeterias.controller.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.controller.ts
@@ -6,8 +6,12 @@ import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { ListCafeteriaDietExtraRequestDto } from 'src/api/public/cafeterias/dtos/requests/list-cafeteria-diet-request.dto';
 import { ListCafeteriaRequestDto } from 'src/api/public/cafeterias/dtos/requests/list-cafeteria-request.dto';
+import { CafeteriaMessagesService } from 'src/api/public/cafeterias/cafeteria-messages.service';
+import { CampusesService } from 'src/api/public/campuses/campuses.service';
+import { CampusMessagesService } from 'src/api/public/message-templates/campus-messages.service';
 import { CurrentUser } from 'src/api/public/users/decorators/current-user.decorator';
 import { FetchCurrentUser } from 'src/api/public/users/decorators/fetch-current-user.decorator';
+import { BlockId } from 'src/api/common/utils/constants';
 import { User } from 'src/type-orm/entities/users/users.entity';
 import { CafeteriasService } from './cafeterias.service';
 
@@ -15,7 +19,12 @@ import { CafeteriasService } from './cafeterias.service';
 @Controller('cafeterias')
 @UseFilters(OpenBuilderExceptionFilter)
 export class CafeteriasController {
-  constructor(private readonly cafeteriasService: CafeteriasService) {}
+  constructor(
+    private readonly cafeteriasService: CafeteriasService,
+    private readonly cafeteriaMessagesService: CafeteriaMessagesService,
+    private readonly campusesService: CampusesService,
+    private readonly campusMessagesService: CampusMessagesService,
+  ) {}
 
   @Post()
   @FetchCurrentUser()
@@ -24,13 +33,19 @@ export class CafeteriasController {
     @CurrentUser() user: User,
     @ClientExtra(ListCafeteriaRequestDto) extra: ListCafeteriaRequestDto,
   ) {
-    const { campusId } = extra;
-  
-    const template = await this.cafeteriasService.getCafeteriaListTemplate(
-      user.campus?.id,
-      campusId,
-    );
+    const requestedCampusId = extra.campusId;
+    const userCampusId = user.campus?.id;
 
+    // '더보기' 버튼 또는 캠퍼스 미설정 → 캠퍼스 선택 카드 반환
+    if (requestedCampusId === -1 || (!requestedCampusId && !userCampusId)) {
+      const campuses = await this.campusesService.findAll();
+      const template = this.campusMessagesService.createCampusListCard(campuses, BlockId.CAFETERIA_LIST);
+      return new ResponseDTO(template);
+    }
+
+    const campusId = requestedCampusId ?? userCampusId;
+    const cafeterias = await this.cafeteriasService.getCafeterias(campusId);
+    const template = this.cafeteriaMessagesService.cafeteriasListCard(cafeterias);
     return new ResponseDTO(template);
   }
 
@@ -41,13 +56,13 @@ export class CafeteriasController {
     extra: ListCafeteriaDietExtraRequestDto,
   ) {
     const { cafeteriaId, date, time } = extra;
-
-    const template = await this.cafeteriasService.getCafeteriaDietTemplate(
-      cafeteriaId,
-      date,
-      time,
+    const result = await this.cafeteriasService.getCafeteriaDiet(cafeteriaId, date, time);
+    const template = this.cafeteriaMessagesService.cafeteriaDietsListCard(
+      result.cafeteria,
+      result.date,
+      result.time,
+      result.diets,
     );
-
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/cafeterias/cafeterias.module.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { CafeteriaMessagesService } from 'src/api/public/cafeterias/cafeteria-messages.service';
 import { CampusesModule } from 'src/api/public/campuses/campuses.module';
+import { CampusMessagesService } from 'src/api/public/message-templates/campus-messages.service';
 import { CafeteriasRepositoryModule } from 'src/type-orm/entities/cafeterias/cafeterias-repository.module';
 import { CafeteriasController } from './cafeterias.controller';
 import { CafeteriasService } from './cafeterias.service';
@@ -8,7 +9,7 @@ import { CafeteriasService } from './cafeterias.service';
 @Module({
   imports: [CampusesModule, CafeteriasRepositoryModule],
   controllers: [CafeteriasController],
-  providers: [CafeteriasService, CafeteriaMessagesService],
+  providers: [CafeteriasService, CafeteriaMessagesService, CampusMessagesService],
   exports: [CafeteriasService],
 })
 export class CafeteriasModule {}

--- a/services/api/app/src/api/public/cafeterias/cafeterias.service.spec.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.service.spec.ts
@@ -1,12 +1,10 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { CafeteriasService } from './cafeterias.service';
-import { CafeteriasRepository } from 'src/type-orm/entities/cafeterias/cafeterias.repository';
-import { CampusesService } from 'src/api/public/campuses/campuses.service';
-import { CafeteriaMessagesService } from './cafeteria-messages.service';
-import { Cafeteria } from 'src/type-orm/entities/cafeterias/cafeteria.entity';
 import { CafeteriaDiet } from 'src/type-orm/entities/cafeterias/cafeteria-diet.entity';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
+import { Cafeteria } from 'src/type-orm/entities/cafeterias/cafeteria.entity';
+import { CafeteriasRepository } from 'src/type-orm/entities/cafeterias/cafeterias.repository';
+import { CafeteriasService } from './cafeterias.service';
 
 const makeCafeteria = (overrides: Partial<Cafeteria> = {}): Cafeteria =>
   ({
@@ -17,15 +15,9 @@ const makeCafeteria = (overrides: Partial<Cafeteria> = {}): Cafeteria =>
     ...overrides,
   } as Cafeteria);
 
-const CAMPUS_LIST_TEMPLATE: SkillTemplate = { outputs: [{ listCard: {} } as any] };
-const CAFETERIA_LIST_TEMPLATE: SkillTemplate = { outputs: [{ listCard: {} } as any] };
-const DIET_TEMPLATE: SkillTemplate = { outputs: [{ basicCard: {} } as any] };
-
 describe('CafeteriasService', () => {
   let service: CafeteriasService;
   let cafeteriasRepository: jest.Mocked<CafeteriasRepository>;
-  let campusesService: jest.Mocked<CampusesService>;
-  let cafeteriaMessagesService: jest.Mocked<CafeteriaMessagesService>;
   let cacheManager: { get: jest.Mock; set: jest.Mock };
 
   beforeEach(async () => {
@@ -41,19 +33,6 @@ describe('CafeteriasService', () => {
           },
         },
         {
-          provide: CampusesService,
-          useValue: {
-            campusesListCard: jest.fn().mockResolvedValue(CAMPUS_LIST_TEMPLATE),
-          },
-        },
-        {
-          provide: CafeteriaMessagesService,
-          useValue: {
-            cafeteriasListCard: jest.fn().mockReturnValue(CAFETERIA_LIST_TEMPLATE),
-            cafeteriaDietsListCard: jest.fn().mockReturnValue(DIET_TEMPLATE),
-          },
-        },
-        {
           provide: CACHE_MANAGER,
           useValue: {
             get: jest.fn().mockResolvedValue(null),
@@ -65,59 +44,33 @@ describe('CafeteriasService', () => {
 
     service = module.get<CafeteriasService>(CafeteriasService);
     cafeteriasRepository = module.get(CafeteriasRepository);
-    campusesService = module.get(CampusesService);
-    cafeteriaMessagesService = module.get(CafeteriaMessagesService);
     cacheManager = module.get(CACHE_MANAGER);
   });
 
-  describe('getCafeteriaListTemplate', () => {
-    it('requestedCampusId가 -1이면 캠퍼스 선택 카드를 반환한다', async () => {
-      const result = await service.getCafeteriaListTemplate(1, -1);
-
-      expect(campusesService.campusesListCard).toHaveBeenCalled();
-      expect(result).toBe(CAMPUS_LIST_TEMPLATE);
-    });
-
-    it('campusId가 없으면 캠퍼스 선택 카드를 반환한다', async () => {
-      const result = await service.getCafeteriaListTemplate(undefined, undefined);
-
-      expect(campusesService.campusesListCard).toHaveBeenCalled();
-      expect(result).toBe(CAMPUS_LIST_TEMPLATE);
-    });
-
-    it('userCampusId만 있으면 해당 캠퍼스의 식당 목록을 반환한다', async () => {
+  describe('getCafeterias', () => {
+    it('캠퍼스 ID로 식당 목록을 반환한다', async () => {
       const cafeterias = [makeCafeteria()];
       cafeteriasRepository.findCafeteriasByCampusId.mockResolvedValue(cafeterias);
 
-      const result = await service.getCafeteriaListTemplate(1, undefined);
+      const result = await service.getCafeterias(1);
 
       expect(cafeteriasRepository.findCafeteriasByCampusId).toHaveBeenCalledWith(1);
-      expect(cafeteriaMessagesService.cafeteriasListCard).toHaveBeenCalledWith(cafeterias);
-      expect(result).toBe(CAFETERIA_LIST_TEMPLATE);
+      expect(result).toBe(cafeterias);
     });
 
-    it('requestedCampusId가 userCampusId보다 우선한다', async () => {
-      const cafeterias = [makeCafeteria({ campus: { id: 2, name: '칠암캠퍼스' } as any })];
-      cafeteriasRepository.findCafeteriasByCampusId.mockResolvedValue(cafeterias);
+    it('cache hit이면 DB 조회 없이 캐시 값을 반환한다', async () => {
+      const cachedCafeterias = [makeCafeteria()];
+      cacheManager.get.mockResolvedValue(cachedCafeterias);
 
-      await service.getCafeteriaListTemplate(1, 2);
+      const result = await service.getCafeterias(1);
 
-      expect(cafeteriasRepository.findCafeteriasByCampusId).toHaveBeenCalledWith(2);
-    });
-
-    it('requestedCampusId가 있으면 해당 캠퍼스의 식당 목록을 반환한다', async () => {
-      const cafeterias = [makeCafeteria()];
-      cafeteriasRepository.findCafeteriasByCampusId.mockResolvedValue(cafeterias);
-
-      const result = await service.getCafeteriaListTemplate(undefined, 3);
-
-      expect(cafeteriasRepository.findCafeteriasByCampusId).toHaveBeenCalledWith(3);
-      expect(result).toBe(CAFETERIA_LIST_TEMPLATE);
+      expect(result).toBe(cachedCafeterias);
+      expect(cafeteriasRepository.findCafeteriasByCampusId).not.toHaveBeenCalled();
     });
   });
 
-  describe('getCafeteriaDietTemplate', () => {
-    it('식당 정보와 식단 목록을 조회하여 메시지를 생성한다', async () => {
+  describe('getCafeteriaDiet', () => {
+    it('식당 정보와 식단 목록을 포함한 결과를 반환한다', async () => {
       const cafeteria = makeCafeteria({ id: 5 });
       const diets: CafeteriaDiet[] = [
         { id: 1, cafeteriaId: 5, dishName: '김치찌개', dishCategory: '한식', dishType: '국' } as any,
@@ -125,21 +78,12 @@ describe('CafeteriasService', () => {
       cafeteriasRepository.findCafeteriaById.mockResolvedValue(cafeteria);
       cafeteriasRepository.findCafeteriaDietsByCafeteriaId.mockResolvedValue(diets);
 
-      const result = await service.getCafeteriaDietTemplate(5, '오늘', '점심');
+      const result = await service.getCafeteriaDiet(5, '오늘', '점심');
 
-      expect(cafeteriasRepository.findCafeteriaById).toHaveBeenCalledWith(5);
-      expect(cafeteriasRepository.findCafeteriaDietsByCafeteriaId).toHaveBeenCalledWith(
-        5,
-        expect.any(Date),
-        '점심',
-      );
-      expect(cafeteriaMessagesService.cafeteriaDietsListCard).toHaveBeenCalledWith(
-        cafeteria,
-        expect.any(Date),
-        '점심',
-        diets,
-      );
-      expect(result).toBe(DIET_TEMPLATE);
+      expect(result.cafeteria).toBe(cafeteria);
+      expect(result.diets).toBe(diets);
+      expect(result.time).toBe('점심');
+      expect(result.date).toBeInstanceOf(Date);
     });
 
     it('dietTime이 없으면 현재 시각 기반으로 자동 결정된다', async () => {
@@ -147,13 +91,9 @@ describe('CafeteriasService', () => {
       cafeteriasRepository.findCafeteriaById.mockResolvedValue(cafeteria);
       cafeteriasRepository.findCafeteriaDietsByCafeteriaId.mockResolvedValue([]);
 
-      await service.getCafeteriaDietTemplate(1, '오늘', undefined);
+      const result = await service.getCafeteriaDiet(1, '오늘', undefined);
 
-      expect(cafeteriasRepository.findCafeteriaDietsByCafeteriaId).toHaveBeenCalledWith(
-        1,
-        expect.any(Date),
-        expect.stringMatching(/^(아침|점심|저녁)$/),
-      );
+      expect(['아침', '점심', '저녁']).toContain(result.time);
     });
 
     it('dietDate가 "내일"이면 내일 날짜로 조회한다', async () => {
@@ -164,22 +104,18 @@ describe('CafeteriasService', () => {
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
 
-      await service.getCafeteriaDietTemplate(1, '내일', '아침');
+      const result = await service.getCafeteriaDiet(1, '내일', '아침');
 
-      const calledDate = cafeteriasRepository.findCafeteriaDietsByCafeteriaId.mock.calls[0][1];
-      expect(calledDate.getDate()).toBe(tomorrow.getDate());
+      expect(result.date.getDate()).toBe(tomorrow.getDate());
     });
-  });
 
-  describe('캐시', () => {
-    it('cache hit이면 DB 조회 없이 캐시 값을 반환한다', async () => {
-      cacheManager.get.mockResolvedValue(DIET_TEMPLATE);
+    it('식당을 찾을 수 없으면 NotFoundException을 던진다', async () => {
+      cafeteriasRepository.findCafeteriaById.mockResolvedValue(null);
+      cafeteriasRepository.findCafeteriaDietsByCafeteriaId.mockResolvedValue([]);
 
-      const result = await service.getCafeteriaDietTemplate(1, '오늘', '점심');
-
-      expect(result).toBe(DIET_TEMPLATE);
-      expect(cafeteriasRepository.findCafeteriaById).not.toHaveBeenCalled();
-      expect(cafeteriasRepository.findCafeteriaDietsByCafeteriaId).not.toHaveBeenCalled();
+      await expect(service.getCafeteriaDiet(999, '오늘', '점심')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('cache miss이면 DB를 조회하고 결과를 캐시에 저장한다', async () => {
@@ -187,7 +123,7 @@ describe('CafeteriasService', () => {
       cafeteriasRepository.findCafeteriaById.mockResolvedValue(makeCafeteria());
       cafeteriasRepository.findCafeteriaDietsByCafeteriaId.mockResolvedValue([]);
 
-      const result = await service.getCafeteriaDietTemplate(1, '오늘', '점심');
+      const result = await service.getCafeteriaDiet(1, '오늘', '점심');
 
       expect(cafeteriasRepository.findCafeteriaById).toHaveBeenCalledWith(1);
       expect(cacheManager.set).toHaveBeenCalledWith(

--- a/services/api/app/src/api/public/cafeterias/cafeterias.service.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.service.ts
@@ -1,9 +1,6 @@
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { CacheKey } from 'src/api/common/decorators/cache-key.decorator';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { BlockId } from 'src/api/common/utils/constants';
-import { CafeteriaMessagesService } from 'src/api/public/cafeterias/cafeteria-messages.service';
 import {
   DietDate,
   DietTime,
@@ -12,8 +9,16 @@ import {
   getDietTime,
   getTodayOrTomorrow,
 } from 'src/api/public/cafeterias/utils/time';
-import { CampusesService } from 'src/api/public/campuses/campuses.service';
 import { CafeteriasRepository } from 'src/type-orm/entities/cafeterias/cafeterias.repository';
+import { CafeteriaDiet } from 'src/type-orm/entities/cafeterias/cafeteria-diet.entity';
+import { Cafeteria } from 'src/type-orm/entities/cafeterias/cafeteria.entity';
+
+export interface CafeteriaDietResult {
+  cafeteria: Cafeteria;
+  diets: CafeteriaDiet[];
+  date: Date;
+  time: DietTime;
+}
 
 @Injectable()
 export class CafeteriasService {
@@ -21,53 +26,21 @@ export class CafeteriasService {
 
   constructor(
     private readonly cafeteriasRepository: CafeteriasRepository,
-    private readonly campusesService: CampusesService,
-    private readonly cafeteriaMessagesService: CafeteriaMessagesService,
     @Inject(CACHE_MANAGER) readonly cacheManager: Cache,
   ) {}
 
   /**
-   * 식당 목록 템플릿 조회
+   * 캠퍼스별 식당 목록 조회
    */
   @CacheKey({
-    key: ([userCampusId, requestedCampusId]) => {
-      if (requestedCampusId === -1) {
-        return 'cafeteria-list:campus-select';
-      }
-      const campusId =
-        (requestedCampusId as number | undefined) ?? (userCampusId as number | undefined);
-      if (!campusId) {
-        return 'cafeteria-list:campus-select';
-      }
-      return `cafeteria-list:campus:${campusId}`;
-    },
+    key: ([campusId]) => `cafeteria-list:campus:${campusId as number}`,
   })
-  public async getCafeteriaListTemplate(
-    userCampusId?: number,
-    requestedCampusId?: number,
-  ): Promise<SkillTemplate> {
-    // 1. '더보기' 버튼을 누른 경우 캠퍼스 선택 카드 반환
-    if (requestedCampusId === -1) {
-      return this.campusesService.campusesListCard(BlockId.CAFETERIA_LIST);
-    }
-
-    // 2. 캠퍼스 ID 결정: 요청된 캠퍼스 ID 우선, 없으면 사용자 캠퍼스 ID 사용
-    const campusId = requestedCampusId ?? userCampusId;
-
-    // 3. 캠퍼스 ID가 없으면 캠퍼스 선택 카드 반환 (비로그인 유저 최초 진입)
-    if (!campusId) {
-      return this.campusesService.campusesListCard(BlockId.CAFETERIA_LIST);
-    }
-
-    // 4. 식당 목록 조회
-    const cafeterias = await this.cafeteriasRepository.findCafeteriasByCampusId(campusId);
-
-    // 5. 식당 목록 카드 생성
-    return this.cafeteriaMessagesService.cafeteriasListCard(cafeterias);
+  public async getCafeterias(campusId: number): Promise<Cafeteria[]> {
+    return this.cafeteriasRepository.findCafeteriasByCampusId(campusId);
   }
 
   /**
-   * 식당 식단 템플릿 조회
+   * 식당 식단 정보 조회
    */
   @CacheKey({
     key: ([cafeteriaId, dietDate, dietTime]) => {
@@ -76,33 +49,26 @@ export class CafeteriasService {
       return `diet:${cafeteriaId as number}:${date.toISOString().slice(0, 10)}:${time}`;
     },
   })
-  public async getCafeteriaDietTemplate(
+  public async getCafeteriaDiet(
     cafeteriaId: number,
     dietDate?: DietDate,
     dietTime?: DietTime,
-  ): Promise<SkillTemplate> {
-    // 1. 날짜 및 시간 기본값 설정 (시간대에 따라 오늘 또는 내일 날짜 반환)
+  ): Promise<CafeteriaDietResult> {
     const date = getTodayOrTomorrow(dietDate);
     const time = dietTime ?? getDietTime(date);
 
-    // 2. 식당 정보 및 식단 목록 조회
     const cafeteria = await this.cafeteriasRepository.findCafeteriaById(cafeteriaId);
+
+    if (!cafeteria) {
+      throw new NotFoundException(`식당(${cafeteriaId}) 정보를 찾을 수 없습니다.`);
+    }
+
     const diets = await this.cafeteriasRepository.findCafeteriaDietsByCafeteriaId(
       cafeteriaId,
       date,
       time,
     );
 
-    if (!cafeteria) {
-      throw new NotFoundException(`식당(${cafeteriaId}) 정보를 찾을 수 없습니다.`);
-    }
-
-    // 3. 식단 카드 생성
-    return this.cafeteriaMessagesService.cafeteriaDietsListCard(
-      cafeteria,
-      date,
-      time,
-      diets,
-    );
+    return { cafeteria, diets, date, time };
   }
 }

--- a/services/api/app/src/api/public/campuses/campuses.module.ts
+++ b/services/api/app/src/api/public/campuses/campuses.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { MessagesModule } from 'src/api/public/message-templates/messages.module';
 import { Campus } from 'src/type-orm/entities/campuses/campus.entity';
 import { CampusesRepository } from 'src/type-orm/entities/campuses/campuses.repository';
 import { CampusesService } from './campuses.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Campus]), MessagesModule],
+  imports: [TypeOrmModule.forFeature([Campus])],
   providers: [CampusesService, CampusesRepository],
   exports: [CampusesService],
 })

--- a/services/api/app/src/api/public/campuses/campuses.service.ts
+++ b/services/api/app/src/api/public/campuses/campuses.service.ts
@@ -1,7 +1,5 @@
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { CampusMessagesService } from 'src/api/public/message-templates/campus-messages.service';
 import { Campus } from 'src/type-orm/entities/campuses/campus.entity';
 import { CampusesRepository } from 'src/type-orm/entities/campuses/campuses.repository';
 import { CacheKey } from 'src/api/common/decorators/cache-key.decorator';
@@ -12,19 +10,13 @@ export class CampusesService {
 
   constructor(
     private readonly campusesRepository: CampusesRepository,
-    private readonly campusMessagesService: CampusMessagesService,
     @Inject(CACHE_MANAGER) readonly cacheManager: Cache,
   ) {}
 
   @CacheKey({
-    key: ([blockId]) => `campuses:${blockId}`,
+    key: () => 'campuses',
   })
-  public async campusesListCard(blockId: string): Promise<SkillTemplate> {
-    const campuses = await this.findAll();
-    return this.campusMessagesService.createCampusListCard(campuses, blockId);
-  }
-
-  private findAll(): Promise<Campus[]> {
+  public findAll(): Promise<Campus[]> {
     return this.campusesRepository.findAll();
   }
 }

--- a/services/api/app/src/api/public/colleges/colleges.module.ts
+++ b/services/api/app/src/api/public/colleges/colleges.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CollegeMessagesService } from 'src/api/public/message-templates/college-messages.service';
 import { College } from 'src/type-orm/entities/colleges/college.entity';
 import { CollegesRepository } from 'src/type-orm/entities/colleges/colleges.repository';
 import { CollegesService } from './colleges.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([College])],
-  providers: [CollegesService, CollegesRepository, CollegeMessagesService],
+  providers: [CollegesService, CollegesRepository],
   exports: [CollegesService],
 })
 export class CollegesModule {}

--- a/services/api/app/src/api/public/colleges/colleges.service.ts
+++ b/services/api/app/src/api/public/colleges/colleges.service.ts
@@ -1,8 +1,5 @@
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { CollegeMessagesService } from 'src/api/public/message-templates/college-messages.service';
-import { ListCollegesRequestDto } from 'src/api/public/users/dtos/requests/list-college-request.dto';
 import { College } from 'src/type-orm/entities/colleges/college.entity';
 import { CollegesRepository } from 'src/type-orm/entities/colleges/colleges.repository';
 import { CacheKey } from 'src/api/common/decorators/cache-key.decorator';
@@ -13,28 +10,13 @@ export class CollegesService {
 
   constructor(
     private readonly collegesRepository: CollegesRepository,
-    private readonly collegeMessagesService: CollegeMessagesService,
     @Inject(CACHE_MANAGER) readonly cacheManager: Cache,
   ) {}
 
   @CacheKey({
-    key: ([blockId]) => `colleges:${blockId}`,
+    key: ([page]) => `colleges:page:${page as number}`,
   })
-  public async collegesListCard(
-    extra: ListCollegesRequestDto,
-    blockId: string,
-  ): Promise<SkillTemplate> {
-    const [colleges, total] = await this.findAll(extra.page);
-    return this.collegeMessagesService.collegesListCard(
-      colleges,
-      total,
-      extra.campusId,
-      extra.page,
-      blockId,
-    );
-  }
-
-  private findAll(page: number): Promise<[College[], number]> {
+  public findAll(page: number): Promise<[College[], number]> {
     return this.collegesRepository.findAll(page);
   }
 }

--- a/services/api/app/src/api/public/departments/departments.module.ts
+++ b/services/api/app/src/api/public/departments/departments.module.ts
@@ -1,16 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { DepartmentMessagesService } from 'src/api/public/message-templates/department-messages.service';
 import { Department } from 'src/type-orm/entities/departments/department.entity';
 import { DepartmentsRepository } from 'src/type-orm/entities/departments/departments.repository';
 import { DepartmentsService } from './departments.service';
+
 @Module({
   imports: [TypeOrmModule.forFeature([Department])],
-  providers: [
-    DepartmentsService,
-    DepartmentsRepository,
-    DepartmentMessagesService,
-  ],
+  providers: [DepartmentsService, DepartmentsRepository],
   exports: [DepartmentsService],
 })
 export class DepartmentsModule {}

--- a/services/api/app/src/api/public/departments/departments.service.ts
+++ b/services/api/app/src/api/public/departments/departments.service.ts
@@ -1,7 +1,5 @@
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { DepartmentMessagesService } from 'src/api/public/message-templates/department-messages.service';
 import { ListDepartmentsRequestDto } from 'src/api/public/users/dtos/requests/list-department-request.dto';
 import { Department } from 'src/type-orm/entities/departments/department.entity';
 import { DepartmentsRepository } from 'src/type-orm/entities/departments/departments.repository';
@@ -13,32 +11,16 @@ export class DepartmentsService {
 
   constructor(
     private readonly departmentsRepository: DepartmentsRepository,
-    private readonly departmentMessagesService: DepartmentMessagesService,
     @Inject(CACHE_MANAGER) readonly cacheManager: Cache,
   ) {}
 
   @CacheKey({
-    key: ([blockId]) => `departments:${blockId}`,
+    key: ([extra]) => {
+      const { collegeId, page } = extra as ListDepartmentsRequestDto;
+      return `departments:college:${collegeId}:page:${page}`;
+    },
   })
-  public async departmentsListCard(
-    extra: ListDepartmentsRequestDto,
-    blockId: string,
-  ): Promise<SkillTemplate> {
-    const [departments, total] = await this.findAll(extra);
-    return this.departmentMessagesService.departmentsListCard(
-      departments,
-      total,
-      extra,
-      blockId,
-    );
-  }
-
-  private findAll(
-    extra: ListDepartmentsRequestDto,
-  ): Promise<[Department[], number]> {
-    return this.departmentsRepository.findByCollegeId(
-      extra.collegeId,
-      extra.page,
-    );
+  public findAll(extra: ListDepartmentsRequestDto): Promise<[Department[], number]> {
+    return this.departmentsRepository.findByCollegeId(extra.collegeId, extra.page);
   }
 }

--- a/services/api/app/src/api/public/notices/notices.controller.ts
+++ b/services/api/app/src/api/public/notices/notices.controller.ts
@@ -3,6 +3,8 @@ import { ApiTags } from '@nestjs/swagger';
 import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
+import { CommonMessagesService } from 'src/api/public/message-templates/common-messages.service';
+import { NoticeMessagesService } from 'src/api/public/message-templates/notice-messages.service';
 import { CurrentUser } from 'src/api/public/users/decorators/current-user.decorator';
 import { FetchCurrentUser } from 'src/api/public/users/decorators/fetch-current-user.decorator';
 import { User } from 'src/type-orm/entities/users/users.entity';
@@ -14,12 +16,23 @@ import { NoticesService } from './notices.service';
 @Controller('notices')
 @UseFilters(OpenBuilderExceptionFilter)
 export class NoticesController {
-  constructor(private readonly noticesService: NoticesService) {}
+  constructor(
+    private readonly noticesService: NoticesService,
+    private readonly noticeMessagesService: NoticeMessagesService,
+    private readonly commonMessagesService: CommonMessagesService,
+  ) {}
 
   @Post('university')
   @ApiSkillBody(ListUniversityNoticeRequestDto)
   async listUniversityNotices() {
-    const template = await this.noticesService.getUniversityNoticeTemplate();
+    const noticesMap = await this.noticesService.getUniversityNotices();
+
+    if (noticesMap.size === 0) {
+      const template = this.commonMessagesService.createSimpleText('현재 등록된 공지사항이 없어!');
+      return new ResponseDTO(template);
+    }
+
+    const template = this.noticeMessagesService.createUniversityNoticeCarousel(noticesMap);
     return new ResponseDTO(template);
   }
 
@@ -27,7 +40,19 @@ export class NoticesController {
   @FetchCurrentUser()
   @ApiSkillBody(ListDepartmentNoticeRequestDto)
   async listDepartmentNotices(@CurrentUser() user: User) {
-    const template = await this.noticesService.getDepartmentNoticeTemplate(user);
+    if (!user.department) {
+      const template = this.commonMessagesService.createDepartmentAuthRequiredMessage();
+      return new ResponseDTO(template);
+    }
+
+    const noticesMap = await this.noticesService.getDepartmentNotices(user);
+
+    if (noticesMap.size === 0) {
+      const template = this.commonMessagesService.createSimpleText('현재 등록된 공지사항이 없어!');
+      return new ResponseDTO(template);
+    }
+
+    const template = this.noticeMessagesService.createDepartmentNoticeCarousel(noticesMap);
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/notices/notices.service.spec.ts
+++ b/services/api/app/src/api/public/notices/notices.service.spec.ts
@@ -1,13 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NoticesService } from './notices.service';
-import { NoticesRepository } from 'src/type-orm/entities/notices/notices.repository';
 import { NoticeCategoriesRepository } from 'src/type-orm/entities/notices/notice-categories.repository';
-import { NoticeMessagesService } from 'src/api/public/message-templates/notice-messages.service';
-import { CommonMessagesService } from 'src/api/public/message-templates/common-messages.service';
 import { NoticeCategory } from 'src/type-orm/entities/notices/notice-category.entity';
 import { Notice } from 'src/type-orm/entities/notices/notice.entity';
+import { NoticesRepository } from 'src/type-orm/entities/notices/notices.repository';
 import { User } from 'src/type-orm/entities/users/users.entity';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
+import { NoticesService } from './notices.service';
 
 const makeCategory = (overrides: Partial<NoticeCategory> = {}): NoticeCategory =>
   ({
@@ -46,16 +43,10 @@ const makeUser = (overrides: Partial<User> = {}): User =>
     ...overrides,
   } as User);
 
-const SIMPLE_TEXT_TEMPLATE: SkillTemplate = { outputs: [{ simpleText: { text: '' } } as any] };
-const AUTH_REQUIRED_TEMPLATE: SkillTemplate = { outputs: [{ textCard: {} } as any] };
-const CAROUSEL_TEMPLATE: SkillTemplate = { outputs: [{ carousel: {} } as any] };
-
 describe('NoticesService', () => {
   let service: NoticesService;
   let noticesRepository: jest.Mocked<NoticesRepository>;
   let noticeCategoriesRepository: jest.Mocked<NoticeCategoriesRepository>;
-  let noticeMessagesService: jest.Mocked<NoticeMessagesService>;
-  let commonMessagesService: jest.Mocked<CommonMessagesService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -74,72 +65,49 @@ describe('NoticesService', () => {
             findByDepartmentIds: jest.fn(),
           },
         },
-        {
-          provide: NoticeMessagesService,
-          useValue: {
-            createUniversityNoticeCarousel: jest.fn(),
-            createDepartmentNoticeCarousel: jest.fn(),
-          },
-        },
-        {
-          provide: CommonMessagesService,
-          useValue: {
-            createSimpleText: jest.fn().mockReturnValue(SIMPLE_TEXT_TEMPLATE),
-            createDepartmentAuthRequiredMessage: jest.fn().mockReturnValue(AUTH_REQUIRED_TEMPLATE),
-          },
-        },
       ],
     }).compile();
 
     service = module.get<NoticesService>(NoticesService);
     noticesRepository = module.get(NoticesRepository);
     noticeCategoriesRepository = module.get(NoticeCategoriesRepository);
-    noticeMessagesService = module.get(NoticeMessagesService);
-    commonMessagesService = module.get(CommonMessagesService);
   });
 
-  describe('getUniversityNoticeTemplate', () => {
-    it('카테고리가 없으면 "카테고리를 찾을 수 없습니다" 메시지를 반환한다', async () => {
+  describe('getUniversityNotices', () => {
+    it('카테고리가 없으면 빈 Map을 반환한다', async () => {
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([]);
 
-      const result = await service.getUniversityNoticeTemplate();
+      const result = await service.getUniversityNotices();
 
-      expect(commonMessagesService.createSimpleText).toHaveBeenCalledWith(
-        '학교 공지사항 카테고리를 찾을 수 없습니다.',
-      );
-      expect(result).toBe(SIMPLE_TEXT_TEMPLATE);
+      expect(result.size).toBe(0);
     });
 
-    it('공지사항이 없으면 "현재 등록된 공지사항이 없습니다" 메시지를 반환한다', async () => {
+    it('공지사항이 없으면 빈 Map을 반환한다', async () => {
       const category = makeCategory({ id: 1, category: '학사' });
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([category]);
-      // 모든 카테고리에 공지 없음
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
 
-      const result = await service.getUniversityNoticeTemplate();
+      const result = await service.getUniversityNotices();
 
-      expect(commonMessagesService.createSimpleText).toHaveBeenCalledWith(
-        '현재 등록된 공지사항이 없습니다.',
-      );
-      expect(result).toBe(SIMPLE_TEXT_TEMPLATE);
+      expect(result.size).toBe(0);
     });
 
-    it('공지가 있으면 createUniversityNoticeCarousel을 호출한다', async () => {
+    it('공지가 있으면 카테고리-공지 Map을 반환한다', async () => {
       const category = makeCategory({ id: 1, category: '학사' });
       const notice = makeNotice({ categoryId: 1 });
       const noticeMap = new Map([[1, [notice]]]);
 
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([category]);
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(noticeMap);
-      noticeMessagesService.createUniversityNoticeCarousel.mockReturnValue(CAROUSEL_TEMPLATE);
 
-      const result = await service.getUniversityNoticeTemplate();
+      const result = await service.getUniversityNotices();
 
-      expect(noticeMessagesService.createUniversityNoticeCarousel).toHaveBeenCalled();
-      expect(result).toBe(CAROUSEL_TEMPLATE);
+      expect(result.size).toBe(1);
+      expect([...result.keys()][0]).toBe(category);
+      expect([...result.values()][0]).toEqual([notice]);
     });
 
-    it('TARGET_CATEGORIES 순서대로 캐러셀 Map이 구성된다', async () => {
+    it('TARGET_CATEGORIES 순서대로 Map이 구성된다', async () => {
       const TARGET_CATEGORIES = ['기관', '채용', '장학', '외부기관 행사', '학사'];
       const categories = TARGET_CATEGORIES.map((cat, idx) =>
         makeCategory({ id: idx + 1, category: cat }),
@@ -150,21 +118,16 @@ describe('NoticesService', () => {
 
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue(categories);
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(noticeMap);
-      noticeMessagesService.createUniversityNoticeCarousel.mockReturnValue(CAROUSEL_TEMPLATE);
 
-      await service.getUniversityNoticeTemplate();
+      const result = await service.getUniversityNotices();
 
-      const passedMap: Map<NoticeCategory, Notice[]> =
-        noticeMessagesService.createUniversityNoticeCarousel.mock.calls[0][0];
-
-      const keys = [...passedMap.keys()].map((c) => c.category);
+      const keys = [...result.keys()].map((c) => c.category);
       expect(keys).toEqual(TARGET_CATEGORIES);
     });
 
-    it('공지가 없는 카테고리는 캐러셀 Map에서 제외된다', async () => {
+    it('공지가 없는 카테고리는 Map에서 제외된다', async () => {
       const catWithNotices = makeCategory({ id: 1, category: '학사' });
       const catWithoutNotices = makeCategory({ id: 2, category: '채용' });
-      // id 1만 공지 있음
       const noticeMap = new Map([[1, [makeNotice({ categoryId: 1 })]]]);
 
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([
@@ -172,21 +135,17 @@ describe('NoticesService', () => {
         catWithoutNotices,
       ]);
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(noticeMap);
-      noticeMessagesService.createUniversityNoticeCarousel.mockReturnValue(CAROUSEL_TEMPLATE);
 
-      await service.getUniversityNoticeTemplate();
+      const result = await service.getUniversityNotices();
 
-      const passedMap: Map<NoticeCategory, Notice[]> =
-        noticeMessagesService.createUniversityNoticeCarousel.mock.calls[0][0];
-
-      expect(passedMap.size).toBe(1);
-      expect([...passedMap.keys()][0].id).toBe(1);
+      expect(result.size).toBe(1);
+      expect([...result.keys()][0].id).toBe(1);
     });
 
     it('department_id 117로 카테고리를 조회한다', async () => {
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([]);
 
-      await service.getUniversityNoticeTemplate();
+      await service.getUniversityNotices();
 
       expect(noticeCategoriesRepository.findByDepartmentIdAndCategories).toHaveBeenCalledWith(
         117,
@@ -195,55 +154,46 @@ describe('NoticesService', () => {
     });
   });
 
-  describe('getDepartmentNoticeTemplate', () => {
-    it('user.department가 null이면 학과 등록 안내 메시지를 반환한다', async () => {
+  describe('getDepartmentNotices', () => {
+    it('user.department가 null이면 빈 Map을 반환한다', async () => {
       const user = makeUser({ department: null });
 
-      const result = await service.getDepartmentNoticeTemplate(user);
+      const result = await service.getDepartmentNotices(user);
 
-      expect(commonMessagesService.createDepartmentAuthRequiredMessage).toHaveBeenCalled();
-      expect(result).toBe(AUTH_REQUIRED_TEMPLATE);
+      expect(result.size).toBe(0);
     });
 
-    it('카테고리가 없으면 "등록된 공지사항 게시판이 없습니다" 메시지를 반환한다', async () => {
+    it('카테고리가 없으면 빈 Map을 반환한다', async () => {
       const user = makeUser();
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([]);
 
-      const result = await service.getDepartmentNoticeTemplate(user);
+      const result = await service.getDepartmentNotices(user);
 
-      expect(commonMessagesService.createSimpleText).toHaveBeenCalledWith(
-        '등록된 공지사항 게시판이 없습니다.',
-      );
-      expect(result).toBe(SIMPLE_TEXT_TEMPLATE);
+      expect(result.size).toBe(0);
     });
 
-    it('공지사항이 없으면 "현재 등록된 공지사항이 없습니다" 메시지를 반환한다', async () => {
+    it('공지사항이 없으면 빈 Map을 반환한다', async () => {
       const user = makeUser();
       const category = makeCategory({ id: 1 });
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([category]);
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
 
-      const result = await service.getDepartmentNoticeTemplate(user);
+      const result = await service.getDepartmentNotices(user);
 
-      expect(commonMessagesService.createSimpleText).toHaveBeenCalledWith(
-        '현재 등록된 공지사항이 없습니다.',
-      );
-      expect(result).toBe(SIMPLE_TEXT_TEMPLATE);
+      expect(result.size).toBe(0);
     });
 
-    it('공지가 있으면 createDepartmentNoticeCarousel을 호출한다', async () => {
+    it('공지가 있으면 카테고리-공지 Map을 반환한다', async () => {
       const user = makeUser();
       const category = makeCategory({ id: 1 });
       const noticeMap = new Map([[1, [makeNotice()]]]);
 
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([category]);
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(noticeMap);
-      noticeMessagesService.createDepartmentNoticeCarousel.mockReturnValue(CAROUSEL_TEMPLATE);
 
-      const result = await service.getDepartmentNoticeTemplate(user);
+      const result = await service.getDepartmentNotices(user);
 
-      expect(noticeMessagesService.createDepartmentNoticeCarousel).toHaveBeenCalled();
-      expect(result).toBe(CAROUSEL_TEMPLATE);
+      expect(result.size).toBe(1);
     });
 
     it('parentDepartmentId가 있으면 departmentIds에 부모 학과 ID도 포함된다', async () => {
@@ -257,7 +207,7 @@ describe('NoticesService', () => {
       });
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([]);
 
-      await service.getDepartmentNoticeTemplate(user);
+      await service.getDepartmentNotices(user);
 
       expect(noticeCategoriesRepository.findByDepartmentIds).toHaveBeenCalledWith(
         expect.arrayContaining([10, 5]),
@@ -275,7 +225,7 @@ describe('NoticesService', () => {
       });
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([]);
 
-      await service.getDepartmentNoticeTemplate(user);
+      await service.getDepartmentNotices(user);
 
       expect(noticeCategoriesRepository.findByDepartmentIds).toHaveBeenCalledWith([10]);
     });

--- a/services/api/app/src/api/public/notices/notices.service.ts
+++ b/services/api/app/src/api/public/notices/notices.service.ts
@@ -1,19 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { NoticeMessagesService } from 'src/api/public/message-templates/notice-messages.service';
 import { NoticeCategoriesRepository } from 'src/type-orm/entities/notices/notice-categories.repository';
 import { NoticeCategory } from 'src/type-orm/entities/notices/notice-category.entity';
 import { Notice } from 'src/type-orm/entities/notices/notice.entity';
 import { NoticesRepository } from 'src/type-orm/entities/notices/notices.repository';
 import { User } from 'src/type-orm/entities/users/users.entity';
-import { CommonMessagesService } from '../message-templates/common-messages.service';
 
 @Injectable()
 export class NoticesService {
-  // 학교 공지사항 department_id
   private readonly UNIVERSITY_DEPARTMENT_ID = 117;
 
-  // 조회할 카테고리 목록
   private readonly TARGET_CATEGORIES = [
     '기관',
     '채용',
@@ -22,22 +17,18 @@ export class NoticesService {
     '학사',
   ];
 
-  // 캐러셀형 ListCard의 최대 아이템 수
   private readonly CAROUSEL_ITEMS_LIMIT = 4;
 
   constructor(
     private readonly noticesRepository: NoticesRepository,
     private readonly noticeCategoriesRepository: NoticeCategoriesRepository,
-    private readonly noticeMessagesService: NoticeMessagesService,
-    private readonly commonMessagesService: CommonMessagesService,
   ) {}
 
   /**
-   * 학교 공지사항 템플릿 생성
-   * @returns SkillTemplate (캐러셀 형태의 5개 ListCard)
+   * 학교 공지사항 조회
+   * @returns 카테고리별 공지사항 Map (데이터가 없으면 빈 Map)
    */
-  async getUniversityNoticeTemplate(): Promise<SkillTemplate> {
-    // 1. 학교 공지 카테고리 조회
+  async getUniversityNotices(): Promise<Map<NoticeCategory, Notice[]>> {
     const categories =
       await this.noticeCategoriesRepository.findByDepartmentIdAndCategories(
         this.UNIVERSITY_DEPARTMENT_ID,
@@ -45,98 +36,68 @@ export class NoticesService {
       );
 
     if (categories.length === 0) {
-      return this.commonMessagesService.createSimpleText(
-        '학교 공지사항 카테고리를 찾을 수 없습니다.',
-      );
+      return new Map();
     }
 
-    // 2. 각 카테고리별 최신 공지 조회
     const categoryIds = categories.map((category) => category.id);
     const noticesByCategory = await this.noticesRepository.findRecentByCategoryIds(
       categoryIds,
       this.CAROUSEL_ITEMS_LIMIT,
     );
 
-    // 3. 카테고리와 공지사항을 매핑
-    const noticesByCategoryEntity = new Map<NoticeCategory, Notice[]>();
-    
-    // TARGET_CATEGORIES 순서대로 정렬
+    const result = new Map<NoticeCategory, Notice[]>();
+
     for (const targetCategory of this.TARGET_CATEGORIES) {
       const category = categories.find((c) => c.category === targetCategory);
       if (category) {
         const notices = noticesByCategory.get(category.id) || [];
         if (notices.length > 0) {
-          noticesByCategoryEntity.set(category, notices);
+          result.set(category, notices);
         }
       }
     }
 
-    if (noticesByCategoryEntity.size === 0) {
-      return this.commonMessagesService.createSimpleText(
-        '현재 등록된 공지사항이 없습니다.',
-      );
-    }
-
-    // 4. 캐러셀 응답 생성
-    return this.noticeMessagesService.createUniversityNoticeCarousel(
-      noticesByCategoryEntity,
-    );
+    return result;
   }
 
   /**
-   * 학과 공지사항 템플릿 생성
-   * @param user 현재 사용자
-   * @returns SkillTemplate (캐러셀 형태의 여러 ListCard)
+   * 학과 공지사항 조회
+   * @param user 현재 사용자 (department 미설정 시 빈 Map 반환)
+   * @returns 카테고리별 공지사항 Map
    */
-  async getDepartmentNoticeTemplate(user: User): Promise<SkillTemplate> {
-    // 1. 학과 인증 체크
+  async getDepartmentNotices(user: User): Promise<Map<NoticeCategory, Notice[]>> {
     if (!user.department) {
-      return this.commonMessagesService.createDepartmentAuthRequiredMessage();
+      return new Map();
     }
 
-    // 2. 학과 ID 수집 (본인 학과 + 상위 학과)
     const departmentIds: number[] = [user.department.id];
     if (user.department.parentDepartmentId) {
       departmentIds.push(user.department.parentDepartmentId);
     }
 
-    // 3. 카테고리 조회
     const categories = await this.noticeCategoriesRepository.findByDepartmentIds(
       departmentIds,
     );
 
     if (categories.length === 0) {
-      return this.commonMessagesService.createSimpleText(
-        '등록된 공지사항 게시판이 없습니다.',
-      );
+      return new Map();
     }
 
-    // 4. 각 카테고리별 최신 공지 조회
     const categoryIds = categories.map((category) => category.id);
     const noticesByCategory = await this.noticesRepository.findRecentByCategoryIds(
       categoryIds,
       this.CAROUSEL_ITEMS_LIMIT,
     );
 
-    // 5. 카테고리와 공지사항을 매핑 (공지사항이 있는 것만)
-    const noticesByCategoryEntity = new Map<NoticeCategory, Notice[]>();
-    
+    const result = new Map<NoticeCategory, Notice[]>();
+
     for (const category of categories) {
       const notices = noticesByCategory.get(category.id) || [];
       if (notices.length > 0) {
-        noticesByCategoryEntity.set(category, notices);
+        result.set(category, notices);
       }
     }
 
-    if (noticesByCategoryEntity.size === 0) {
-      return this.commonMessagesService.createSimpleText(
-        '현재 등록된 공지사항이 없습니다.',
-      );
-    }
-
-    // 6. 캐러셀 응답 생성
-    return this.noticeMessagesService.createDepartmentNoticeCarousel(
-      noticesByCategoryEntity,
-    );
+    return result;
   }
 }

--- a/services/api/app/src/api/public/schedules/schedules.controller.ts
+++ b/services/api/app/src/api/public/schedules/schedules.controller.ts
@@ -1,26 +1,42 @@
-import { Controller, Post, UseFilters } from '@nestjs/common';
+import { BadRequestException, Controller, Post, UseFilters } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator';
+import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
+import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
+import { CommonMessagesService } from 'src/api/public/message-templates/common-messages.service';
+import { ScheduleMessagesService } from 'src/api/public/message-templates/schedule-messages.service';
 import { ListAcademicScheduleExtraDto } from './dtos/requests/list-academic-schedule-request.dto';
 import { SchedulesService } from './schedules.service';
-import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
-import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
 
 @ApiTags('schedules')
 @Controller('schedules')
 @UseFilters(OpenBuilderExceptionFilter)
 export class SchedulesController {
-  constructor(private readonly schedulesService: SchedulesService) {}
+  constructor(
+    private readonly schedulesService: SchedulesService,
+    private readonly scheduleMessagesService: ScheduleMessagesService,
+    private readonly commonMessagesService: CommonMessagesService,
+  ) {}
 
   @Post()
   @ApiSkillBody(ListAcademicScheduleExtraDto)
   async listAcademicSchedules(
     @ClientExtra(ListAcademicScheduleExtraDto) extra: ListAcademicScheduleExtraDto,
   ) {
-    const month = extra.month;
-    const template =
-      await this.schedulesService.getAcademicScheduleTemplate(month);
+    const { month } = extra;
+
+    if (month !== undefined && (month < 1 || month > 12)) {
+      const template = this.commonMessagesService.createSimpleText('올바른 월을 입력해주세요. (1-12)');
+      return new ResponseDTO(template);
+    }
+
+    const result = await this.schedulesService.getAcademicSchedules(month);
+    const template = this.scheduleMessagesService.createAcademicScheduleTextCard(
+      result.year,
+      result.month,
+      result.schedules,
+    );
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/schedules/schedules.module.ts
+++ b/services/api/app/src/api/public/schedules/schedules.module.ts
@@ -2,17 +2,13 @@ import { Module } from '@nestjs/common';
 import { CommonMessagesService } from 'src/api/public/message-templates/common-messages.service';
 import { ScheduleMessagesService } from 'src/api/public/message-templates/schedule-messages.service';
 import { AcademicCalendarsRepositoryModule } from 'src/type-orm/entities/academic-calendars/academic-calendars-repository.module';
-import { SchedulesService } from './schedules.service';
 import { SchedulesController } from 'src/api/public/schedules/schedules.controller';
-import { MessagesModule } from 'src/api/public/message-templates/messages.module';
+import { SchedulesService } from './schedules.service';
 
 @Module({
-  imports: [AcademicCalendarsRepositoryModule, MessagesModule],
+  imports: [AcademicCalendarsRepositoryModule],
   controllers: [SchedulesController],
-  providers: [
-    SchedulesService,
-    ScheduleMessagesService,
-  ],
+  providers: [SchedulesService, ScheduleMessagesService, CommonMessagesService],
   exports: [SchedulesService],
 })
 export class SchedulesModule {}

--- a/services/api/app/src/api/public/schedules/schedules.service.ts
+++ b/services/api/app/src/api/public/schedules/schedules.service.ts
@@ -1,50 +1,36 @@
 import { Injectable } from '@nestjs/common';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { ScheduleMessagesService } from 'src/api/public/message-templates/schedule-messages.service';
+import { AcademicCalendar } from 'src/type-orm/entities/academic-calendars/academic-calendar.entity';
 import { AcademicCalendarsRepository } from 'src/type-orm/entities/academic-calendars/academic-calendars.repository';
-import { CommonMessagesService } from '../message-templates/common-messages.service';
+
+export interface AcademicScheduleResult {
+  year: number;
+  month: number;
+  schedules: AcademicCalendar[];
+}
 
 @Injectable()
 export class SchedulesService {
-  // 학부생 calendar_type
   private readonly UNDERGRADUATE_CALENDAR_TYPE = 1;
 
   constructor(
     private readonly academicCalendarsRepository: AcademicCalendarsRepository,
-    private readonly scheduleMessagesService: ScheduleMessagesService,
-    private readonly commonMessagesService: CommonMessagesService,
   ) {}
 
   /**
-   * 학사일정 템플릿 생성
+   * 학사일정 조회
    * @param month 조회할 월 (선택사항, 기본값: 현재 월)
-   * @returns SkillTemplate
    */
-  async getAcademicScheduleTemplate(month?: number): Promise<SkillTemplate> {
+  async getAcademicSchedules(month?: number): Promise<AcademicScheduleResult> {
     const now = new Date();
     const year = now.getFullYear();
-    const targetMonth = month || now.getMonth() + 1;
+    const targetMonth = month ?? now.getMonth() + 1;
 
-    // 월 유효성 검사
-    if (targetMonth < 1 || targetMonth > 12) {
-      return this.commonMessagesService.createSimpleText(
-        '올바른 월을 입력해주세요. (1-12)',
-      );
-    }
-
-    // 학사일정 조회
-    const schedules =
-      await this.academicCalendarsRepository.findByYearAndMonth(
-        year,
-        targetMonth,
-        this.UNDERGRADUATE_CALENDAR_TYPE,
-      );
-
-    // TextCard 응답 생성
-    return this.scheduleMessagesService.createAcademicScheduleTextCard(
+    const schedules = await this.academicCalendarsRepository.findByYearAndMonth(
       year,
       targetMonth,
-      schedules,
+      this.UNDERGRADUATE_CALENDAR_TYPE,
     );
+
+    return { year, month: targetMonth, schedules };
   }
 }

--- a/services/api/app/src/api/public/shuttles/shuttle-messages.service.ts
+++ b/services/api/app/src/api/public/shuttles/shuttle-messages.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { Button, ListItem } from 'src/api/common/interfaces/response/fields/etc';
+import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
+import { createListCard, createTextCard } from 'src/api/common/utils/component';
+import { BlockId } from 'src/api/common/utils/constants';
+import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
+
+type TimetableJson = Record<string, string[]>;
+
+@Injectable()
+export class ShuttleMessagesService {
+  public createRoutesListCard(routes: ShuttleTimetable[]): SkillTemplate {
+    const title = '🚌 셔틀버스 노선 선택';
+
+    if (routes.length === 0) {
+      return {
+        outputs: [createTextCard(title, '현재 등록된 노선이 없습니다.')],
+      };
+    }
+
+    const header: ListItem = { title };
+
+    const items: ListItem[] = routes.map((route) => ({
+      title: route.routeName,
+      action: 'block',
+      blockId: BlockId.SHUTTLE_TIMETABLE,
+      extra: { routeName: route.routeName },
+    }));
+
+    return {
+      outputs: [createListCard(header, items)],
+    };
+  }
+
+  public createTimetableTextCard(record: ShuttleTimetable): SkillTemplate {
+    const timetable = record.timetable as TimetableJson;
+    const updatedAt = record.updatedAt;
+
+    const descLines: string[] = [];
+
+    for (const [section, times] of Object.entries(timetable)) {
+      descLines.push(`[${section}]`);
+      for (const time of times) {
+        descLines.push(time.replace(/\(금요일 미운행\)/, '❌ 금요일 미운행'));
+      }
+      descLines.push('');
+    }
+
+    const formattedDate = updatedAt.toISOString().slice(0, 16).replace('T', ' ');
+    descLines.push(`ℹ️ 시간표 업데이트: ${formattedDate}`);
+
+    const buttons: Button[] = [
+      {
+        label: '뒤로 가기',
+        action: 'block',
+        blockId: BlockId.SHUTTLE_ROUTES,
+      },
+      {
+        label: '공식 홈페이지',
+        action: 'webLink',
+        webLinkUrl:
+          'https://www.gnu.ac.kr/main/cm/cntnts/cntntsView.do?mi=1358&cntntsId=1194',
+      },
+    ];
+
+    return {
+      outputs: [
+        createTextCard(`🚌 ${record.routeName} 셔틀`, descLines.join('\n'), buttons),
+      ],
+    };
+  }
+}

--- a/services/api/app/src/api/public/shuttles/shuttles.controller.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.controller.ts
@@ -5,17 +5,22 @@ import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
 import { GetShuttleTimetableRequestDto } from './dtos/request/get-shuttle-timetable-request.dto';
+import { ShuttleMessagesService } from './shuttle-messages.service';
 import { ShuttlesService } from './shuttles.service';
 
 @ApiTags('shuttles')
 @Controller('shuttles')
 @UseFilters(OpenBuilderExceptionFilter)
 export class ShuttlesController {
-  constructor(private readonly shuttlesService: ShuttlesService) {}
+  constructor(
+    private readonly shuttlesService: ShuttlesService,
+    private readonly shuttleMessagesService: ShuttleMessagesService,
+  ) {}
 
   @Post('routes')
   public async getRoutesList(): Promise<ResponseDTO> {
-    const template = await this.shuttlesService.getRoutesList();
+    const routes = await this.shuttlesService.getRoutes();
+    const template = this.shuttleMessagesService.createRoutesListCard(routes);
     return new ResponseDTO(template);
   }
 
@@ -25,7 +30,8 @@ export class ShuttlesController {
     @ClientExtra(GetShuttleTimetableRequestDto)
     extra: GetShuttleTimetableRequestDto,
   ): Promise<ResponseDTO> {
-    const template = await this.shuttlesService.getTimetable(extra);
+    const record = await this.shuttlesService.getTimetable(extra.routeName);
+    const template = this.shuttleMessagesService.createTimetableTextCard(record);
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/shuttles/shuttles.module.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from 'src/type-orm/database.module';
 import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
 import { ShuttleTimetableRepository } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.repository';
+import { ShuttleMessagesService } from './shuttle-messages.service';
 import { ShuttlesController } from './shuttles.controller';
 import { ShuttlesService } from './shuttles.service';
 
 @Module({
   imports: [DatabaseModule, TypeOrmModule.forFeature([ShuttleTimetable])],
   controllers: [ShuttlesController],
-  providers: [ShuttlesService, ShuttleTimetableRepository],
+  providers: [ShuttlesService, ShuttleTimetableRepository, ShuttleMessagesService],
 })
 export class ShuttlesModule {}

--- a/services/api/app/src/api/public/shuttles/shuttles.service.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.service.ts
@@ -1,12 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Button, ListItem } from 'src/api/common/interfaces/response/fields/etc';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { createListCard, createTextCard } from 'src/api/common/utils/component';
-import { BlockId } from 'src/api/common/utils/constants';
+import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
 import { ShuttleTimetableRepository } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.repository';
-import { GetShuttleTimetableRequestDto } from './dtos/request/get-shuttle-timetable-request.dto';
-
-type TimetableJson = Record<string, string[]>;
 
 @Injectable()
 export class ShuttlesService {
@@ -14,84 +8,17 @@ export class ShuttlesService {
     private readonly shuttleTimetableRepository: ShuttleTimetableRepository,
   ) {}
 
-  public async getRoutesList(): Promise<SkillTemplate> {
-    const routes = await this.shuttleTimetableRepository.findAll();
-    const title = '🚌 셔틀버스 노선 선택';
-
-    if (routes.length === 0) {
-      return {
-        outputs: [createTextCard(title, '현재 등록된 노선이 없습니다.')],
-      };
-    }
-
-    const header: ListItem = { title };
-
-    const items: ListItem[] = routes.map((route) => ({
-      title: route.routeName,
-      action: 'block',
-      blockId: BlockId.SHUTTLE_TIMETABLE,
-      extra: { routeName: route.routeName },
-    }));
-
-    return {
-      outputs: [createListCard(header, items)],
-    };
+  public getRoutes(): Promise<ShuttleTimetable[]> {
+    return this.shuttleTimetableRepository.findAll();
   }
 
-  public async getTimetable(
-    extra: GetShuttleTimetableRequestDto,
-  ): Promise<SkillTemplate> {
-    const record = await this.shuttleTimetableRepository.findByRouteName(
-      extra.routeName,
-    );
+  public async getTimetable(routeName: string): Promise<ShuttleTimetable> {
+    const record = await this.shuttleTimetableRepository.findByRouteName(routeName);
 
     if (!record) {
-      throw new NotFoundException(
-        `'${extra.routeName}' 노선의 시간표를 찾을 수 없습니다.`,
-      );
+      throw new NotFoundException(`'${routeName}' 노선의 시간표를 찾을 수 없습니다.`);
     }
 
-    const timetable = record.timetable as TimetableJson;
-    const updatedAt = record.updatedAt;
-
-    const descLines: string[] = [];
-
-    for (const [section, times] of Object.entries(timetable)) {
-      descLines.push(`[${section}]`);
-      for (const time of times) {
-        descLines.push(time.replace(/\(금요일 미운행\)/, '❌ 금요일 미운행'));
-      }
-      descLines.push('');
-    }
-
-    const formattedDate = updatedAt
-      .toISOString()
-      .slice(0, 16)
-      .replace('T', ' ');
-    descLines.push(`ℹ️ 시간표 업데이트: ${formattedDate}`);
-
-    const buttons: Button[] = [
-      {
-        label: '뒤로 가기',
-        action: 'block',
-        blockId: BlockId.SHUTTLE_ROUTES,
-      },
-      {
-        label: '공식 홈페이지',
-        action: 'webLink',
-        webLinkUrl:
-          'https://www.gnu.ac.kr/main/cm/cntnts/cntntsView.do?mi=1358&cntntsId=1194',
-      },
-    ];
-
-    return {
-      outputs: [
-        createTextCard(
-          `🚌 ${record.routeName} 셔틀`,
-          descLines.join('\n'),
-          buttons,
-        ),
-      ],
-    };
+    return record;
   }
 }

--- a/services/api/app/src/api/public/users/users.controller.ts
+++ b/services/api/app/src/api/public/users/users.controller.ts
@@ -4,6 +4,15 @@ import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator
 import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
+import { BlockId } from 'src/api/common/utils/constants';
+import { CampusesService } from 'src/api/public/campuses/campuses.service';
+import { CollegesService } from 'src/api/public/colleges/colleges.service';
+import { DepartmentsService } from 'src/api/public/departments/departments.service';
+import { CampusMessagesService } from 'src/api/public/message-templates/campus-messages.service';
+import { CollegeMessagesService } from 'src/api/public/message-templates/college-messages.service';
+import { CommonMessagesService } from 'src/api/public/message-templates/common-messages.service';
+import { DepartmentMessagesService } from 'src/api/public/message-templates/department-messages.service';
+import { UserMessageService } from 'src/api/public/message-templates/user-messages.service';
 import { User } from '../../../type-orm/entities/users/users.entity';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { FetchCurrentUser } from './decorators/fetch-current-user.decorator';
@@ -16,18 +25,29 @@ import { UsersService } from './users.service';
 @Controller('users')
 @UseFilters(OpenBuilderExceptionFilter)
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly campusesService: CampusesService,
+    private readonly collegesService: CollegesService,
+    private readonly departmentsService: DepartmentsService,
+    private readonly campusMessagesService: CampusMessagesService,
+    private readonly collegeMessagesService: CollegeMessagesService,
+    private readonly departmentMessagesService: DepartmentMessagesService,
+    private readonly userMessageService: UserMessageService,
+    private readonly commonMessagesService: CommonMessagesService,
+  ) {}
 
   @Post('profile/get')
   @FetchCurrentUser()
   getProfile(@CurrentUser() user: User): ResponseDTO {
-    const template = this.usersService.profileTextCard(user);
+    const template = this.userMessageService.createProfileMessage(user);
     return new ResponseDTO(template);
   }
 
   @Post('campuses/list')
   async listCampuses(): Promise<ResponseDTO> {
-    const template = await this.usersService.campusesListCard();
+    const campuses = await this.campusesService.findAll();
+    const template = this.campusMessagesService.createCampusListCard(campuses, BlockId.COLLEGE_LIST);
     return new ResponseDTO(template);
   }
 
@@ -36,7 +56,14 @@ export class UsersController {
   async listColleges(
     @ClientExtra(ListCollegesRequestDto) extra: ListCollegesRequestDto,
   ): Promise<ResponseDTO> {
-    const template = await this.usersService.collegesListCard(extra);
+    const [colleges, total] = await this.collegesService.findAll(extra.page ?? 1);
+    const template = this.collegeMessagesService.collegesListCard(
+      colleges,
+      total,
+      extra.campusId,
+      extra.page ?? 1,
+      BlockId.DEPARTMENT_LIST,
+    );
     return new ResponseDTO(template);
   }
 
@@ -45,7 +72,13 @@ export class UsersController {
   async listDepartments(
     @ClientExtra(ListDepartmentsRequestDto) extra: ListDepartmentsRequestDto,
   ): Promise<ResponseDTO> {
-    const template = await this.usersService.departmentsListCard(extra);
+    const [departments, total] = await this.departmentsService.findAll(extra);
+    const template = await this.departmentMessagesService.departmentsListCard(
+      departments,
+      total,
+      extra,
+      BlockId.UPDATE_DEPARTMENT,
+    );
     return new ResponseDTO(template);
   }
 
@@ -57,7 +90,7 @@ export class UsersController {
     @ClientExtra(UpsertDepartmentRequestDto) extra: UpsertDepartmentRequestDto,
   ): Promise<ResponseDTO> {
     await this.usersService.upsert(user.id, extra);
-    const template = this.usersService.upsertTextCard();
+    const template = this.commonMessagesService.createSimpleText('학과 정보를 등록했어!');
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/users/users.service.spec.ts
+++ b/services/api/app/src/api/public/users/users.service.spec.ts
@@ -1,25 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UpsertDepartmentRequestDto } from './dtos/requests/upsert-department-request.dto';
 import { UsersService } from './users.service';
 
 jest.mock('typeorm-transactional', () => ({
   initializeTransactionalContext: jest.fn(),
   Transactional: () => (_target: any, _key: string, descriptor: PropertyDescriptor) => descriptor,
 }));
-import { UsersRepository } from 'src/type-orm/entities/users/users.repository';
-import { UserMessageService } from 'src/api/public/message-templates/user-messages.service';
-import { CampusesService } from 'src/api/public/campuses/campuses.service';
-import { CollegesService } from 'src/api/public/colleges/colleges.service';
-import { DepartmentsService } from 'src/api/public/departments/departments.service';
-import { CommonMessagesService } from 'src/api/public/message-templates/common-messages.service';
-import { User } from 'src/type-orm/entities/users/users.entity';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { UpsertDepartmentRequestDto } from './dtos/requests/upsert-department-request.dto';
 
-const CAMPUS_LIST_TEMPLATE: SkillTemplate = { outputs: [{ listCard: {} } as any] };
-const COLLEGE_LIST_TEMPLATE: SkillTemplate = { outputs: [{ listCard: {} } as any] };
-const DEPARTMENT_LIST_TEMPLATE: SkillTemplate = { outputs: [{ listCard: {} } as any] };
-const PROFILE_TEMPLATE: SkillTemplate = { outputs: [{ textCard: {} } as any] };
-const SIMPLE_TEXT_TEMPLATE: SkillTemplate = { outputs: [{ simpleText: {} } as any] };
+import { User } from 'src/type-orm/entities/users/users.entity';
+import { UsersRepository } from 'src/type-orm/entities/users/users.repository';
 
 const makeUser = (overrides: Partial<User> = {}): User =>
   ({
@@ -38,11 +27,6 @@ const makeUser = (overrides: Partial<User> = {}): User =>
 describe('UsersService', () => {
   let service: UsersService;
   let usersRepository: jest.Mocked<UsersRepository>;
-  let userMessageService: jest.Mocked<UserMessageService>;
-  let campusesService: jest.Mocked<CampusesService>;
-  let collegesService: jest.Mocked<CollegesService>;
-  let departmentsService: jest.Mocked<DepartmentsService>;
-  let commonMessagesService: jest.Mocked<CommonMessagesService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -55,85 +39,11 @@ describe('UsersService', () => {
             save: jest.fn(),
           },
         },
-        {
-          provide: UserMessageService,
-          useValue: {
-            createProfileMessage: jest.fn().mockReturnValue(PROFILE_TEMPLATE),
-          },
-        },
-        {
-          provide: CampusesService,
-          useValue: {
-            campusesListCard: jest.fn().mockResolvedValue(CAMPUS_LIST_TEMPLATE),
-          },
-        },
-        {
-          provide: CollegesService,
-          useValue: {
-            collegesListCard: jest.fn().mockResolvedValue(COLLEGE_LIST_TEMPLATE),
-          },
-        },
-        {
-          provide: DepartmentsService,
-          useValue: {
-            departmentsListCard: jest.fn().mockResolvedValue(DEPARTMENT_LIST_TEMPLATE),
-          },
-        },
-        {
-          provide: CommonMessagesService,
-          useValue: {
-            createSimpleText: jest.fn().mockReturnValue(SIMPLE_TEXT_TEMPLATE),
-          },
-        },
       ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
     usersRepository = module.get(UsersRepository);
-    userMessageService = module.get(UserMessageService);
-    campusesService = module.get(CampusesService);
-    collegesService = module.get(CollegesService);
-    departmentsService = module.get(DepartmentsService);
-    commonMessagesService = module.get(CommonMessagesService);
-  });
-
-  describe('campusesListCard', () => {
-    it('COLLEGE_LIST blockId로 캠퍼스 목록 카드를 반환한다', async () => {
-      const result = await service.campusesListCard();
-
-      expect(campusesService.campusesListCard).toHaveBeenCalledWith(
-        expect.stringMatching(/^[a-f0-9]{24}$/),
-      );
-      expect(result).toBe(CAMPUS_LIST_TEMPLATE);
-    });
-  });
-
-  describe('collegesListCard', () => {
-    it('extra와 DEPARTMENT_LIST blockId로 단과대학 목록 카드를 반환한다', async () => {
-      const extra = { campusId: 1 } as any;
-
-      const result = await service.collegesListCard(extra);
-
-      expect(collegesService.collegesListCard).toHaveBeenCalledWith(
-        extra,
-        expect.stringMatching(/^[a-f0-9]{24}$/),
-      );
-      expect(result).toBe(COLLEGE_LIST_TEMPLATE);
-    });
-  });
-
-  describe('departmentsListCard', () => {
-    it('extra와 UPDATE_DEPARTMENT blockId로 학과 목록 카드를 반환한다', async () => {
-      const extra = { collegeId: 3 } as any;
-
-      const result = await service.departmentsListCard(extra);
-
-      expect(departmentsService.departmentsListCard).toHaveBeenCalledWith(
-        extra,
-        expect.stringMatching(/^[a-f0-9]{24}$/),
-      );
-      expect(result).toBe(DEPARTMENT_LIST_TEMPLATE);
-    });
   });
 
   describe('findOne', () => {
@@ -153,25 +63,6 @@ describe('UsersService', () => {
       const result = await service.findOne('unknown-id');
 
       expect(result).toBeNull();
-    });
-  });
-
-  describe('profileTextCard', () => {
-    it('user 정보를 기반으로 프로필 카드를 반환한다', () => {
-      const user = makeUser();
-
-      const result = service.profileTextCard(user);
-
-      expect(userMessageService.createProfileMessage).toHaveBeenCalledWith(user);
-      expect(result).toBe(PROFILE_TEMPLATE);
-    });
-  });
-
-  describe('upsertTextCard', () => {
-    it('"학과 정보를 등록했어!" 메시지를 반환한다', () => {
-      service.upsertTextCard();
-
-      expect(commonMessagesService.createSimpleText).toHaveBeenCalledWith('학과 정보를 등록했어!');
     });
   });
 

--- a/services/api/app/src/api/public/users/users.service.ts
+++ b/services/api/app/src/api/public/users/users.service.ts
@@ -1,58 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { BlockId } from 'src/api/common/utils/constants';
-import { CampusesService } from 'src/api/public/campuses/campuses.service';
-import { CollegesService } from 'src/api/public/colleges/colleges.service';
-import { DepartmentsService } from 'src/api/public/departments/departments.service';
-import { ListCollegesRequestDto } from 'src/api/public/users/dtos/requests/list-college-request.dto';
-import { ListDepartmentsRequestDto } from 'src/api/public/users/dtos/requests/list-department-request.dto';
 import { UpsertDepartmentRequestDto } from 'src/api/public/users/dtos/requests/upsert-department-request.dto';
 import { Transactional } from 'typeorm-transactional';
 import { User } from '../../../type-orm/entities/users/users.entity';
 import { UsersRepository } from '../../../type-orm/entities/users/users.repository';
-import { CommonMessagesService } from '../message-templates/common-messages.service';
-import { UserMessageService } from '../message-templates/user-messages.service';
 
 @Injectable()
 export class UsersService {
-  constructor(
-    private readonly usersRepository: UsersRepository,
-    private readonly userMessageService: UserMessageService,
-    private readonly campusesService: CampusesService,
-    private readonly collegesService: CollegesService,
-    private readonly departmentsService: DepartmentsService,
-    private readonly commonMessagesService: CommonMessagesService,
-  ) {}
-
-  public async campusesListCard(): Promise<SkillTemplate> {
-    const blockId = BlockId.COLLEGE_LIST;
-    return this.campusesService.campusesListCard(blockId);
-  }
-
-  public async collegesListCard(
-    extra: ListCollegesRequestDto,
-  ): Promise<SkillTemplate> {
-    const blockId = BlockId.DEPARTMENT_LIST;
-    return this.collegesService.collegesListCard(extra, blockId);
-  }
-
-  public async departmentsListCard(
-    extra: ListDepartmentsRequestDto,
-  ): Promise<SkillTemplate> {
-    const blockId = BlockId.UPDATE_DEPARTMENT;
-    return this.departmentsService.departmentsListCard(extra, blockId);
-  }
+  constructor(private readonly usersRepository: UsersRepository) {}
 
   public findOne(userId: string): Promise<User> {
     return this.usersRepository.findOne(userId);
-  }
-
-  public profileTextCard(user: User): SkillTemplate {
-    return this.userMessageService.createProfileMessage(user);
-  }
-
-  public upsertTextCard(): SkillTemplate {
-    return this.commonMessagesService.createSimpleText('학과 정보를 등록했어!');
   }
 
   @Transactional()
@@ -60,10 +17,6 @@ export class UsersService {
     userId: string,
     extra: UpsertDepartmentRequestDto,
   ): Promise<User> {
-    return this.usersRepository.save(
-      userId,
-      extra.campusId,
-      extra.departmentId,
-    );
+    return this.usersRepository.save(userId, extra.campusId, extra.departmentId);
   }
 }


### PR DESCRIPTION
- close #64 

## 📝 기능 설명

도메인 서비스가 카카오 챗봇 응답 포맷(`SkillTemplate`)을 직접 반환하는 구조를 개선합니다.
서비스는 순수 데이터 엔티티를 반환하고, 카카오 UI 블록 조립 책임을 컨트롤러 레이어로 이동하여
Native App에서도 동일한 서비스 레이어를 재사용할 수 있는 기반을 마련합니다.

## 🛠 작업 사항

### 서비스 반환 타입 변경

| 서비스 | 변경 전 | 변경 후 |
|---|---|---|
| `CafeteriasService` | `getCafeteriaListTemplate()` → `SkillTemplate` | `getCafeterias()` → `Cafeteria[]` |
| `CafeteriasService` | `getCafeteriaDietTemplate()` → `SkillTemplate` | `getCafeteriaDiet()` → `CafeteriaDietResult` |
| `NoticesService` | `getUniversityNoticeTemplate()` → `SkillTemplate` | `getUniversityNotices()` → `Map<NoticeCategory, Notice[]>` |
| `NoticesService` | `getDepartmentNoticeTemplate()` → `SkillTemplate` | `getDepartmentNotices()` → `Map<NoticeCategory, Notice[]>` |
| `SchedulesService` | `getAcademicScheduleTemplate()` → `SkillTemplate` | `getAcademicSchedules()` → `AcademicScheduleResult` |
| `ShuttlesService` | `getRoutesList()` → `SkillTemplate` | `getRoutes()` → `ShuttleTimetable[]` |
| `ShuttlesService` | `getTimetable()` → `SkillTemplate` | `getTimetable(routeName)` → `ShuttleTimetable` |
| `CampusesService` | `campusesListCard(blockId)` → `SkillTemplate` | `findAll()` → `Campus[]` |
| `CollegesService` | `collegesListCard()` → `SkillTemplate` | `findAll()` → `[College[], number]` |
| `DepartmentsService` | `departmentsListCard()` → `SkillTemplate` | `findAll()` → `[Department[], number]` |
| `UsersService` | 템플릿 메서드 5개 (`campusesListCard` 등) | 제거 — `findOne()`, `upsert()` 만 유지 |

### 컨트롤러 변경

기존 카카오 컨트롤러들이 `service.getData()` + `messagesService.buildTemplate()` 두 단계로 동작하도록 변경.
각 컨트롤러에 해당 메시지 서비스를 직접 주입.

### 신규 파일

- `shuttles/shuttle-messages.service.ts` — 셔틀 전용 카카오 템플릿 조립 서비스 (기존 `ShuttlesService` 내 로직 분리)

### 캐시 구조 개선

기존에는 카카오 `SkillTemplate` 전체(`blockId`, `action`, `ListCard` 래퍼 포함)가 캐시에 저장되는 구조였으나,
변경 후에는 `@CacheKey` 데코레이터가 데이터 메서드에 적용되어 순수 엔티티(`Cafeteria[]` 등)가 캐시에 저장됩니다.
이로 인해 Kakao / Native 양 채널에서 동일 캐시를 재사용할 수 있습니다.

## ✅ 작업 체크리스트

- [x] 모든 도메인 서비스가 `SkillTemplate` 대신 순수 데이터 엔티티/DTO를 반환한다
- [x] 기존 카카오 엔드포인트의 응답 포맷이 변경되지 않는다
- [x] `@CacheKey` 가 데이터 메서드에 적용되어 순수 엔티티가 캐싱된다
- [x] TypeScript 컴파일 에러 없음
- [x] 기존 테스트가 새 시그니처에 맞게 업데이트된다