### PR TITLE
[Refactor] 챗봇 메시지 생성 책임 분리 (MessageFactory)

### DIFF
--- a/services/api/app/src/api/public/cafeterias/cafeteria-message.factory.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeteria-message.factory.ts
@@ -8,18 +8,21 @@ import {
   DietDate,
   DietTime,
 } from 'src/api/public/cafeterias/dtos/requests/list-cafeteria-diet-request.dto';
+import { CafeteriaDietResult } from 'src/api/public/cafeterias/dtos/results/cafeteria-diet-result.dto';
+import {
+  CafeteriaItemResult,
+  CafeteriaListResult,
+} from 'src/api/public/cafeterias/dtos/results/cafeteria-list-result.dto';
 import { getDayWeek } from 'src/api/public/cafeterias/utils/time';
-import { CafeteriaDiet } from 'src/type-orm/entities/cafeterias/cafeteria-diet.entity';
-import { Cafeteria } from 'src/type-orm/entities/cafeterias/cafeteria.entity';
 
 @Injectable()
-export class CafeteriaMessagesService {
-  public cafeteriasListCard(cafeterias: Cafeteria[]): SkillTemplate {
+export class CafeteriaMessageFactory {
+  public createCafeteriaListCard(result: CafeteriaListResult): SkillTemplate {
     const header: ListItem = {
       title: '어떤 교내 식당 정보가 알고 싶어?',
     };
 
-    const items: ListItem[] = cafeterias.map(cafeteria => ({
+    const items: ListItem[] = result.cafeterias.map(cafeteria => ({
       title: cafeteria.name,
       description: cafeteria.campus.name,
       imageUrl: cafeteria.thumbnailUrl,
@@ -48,12 +51,8 @@ export class CafeteriaMessagesService {
     };
   }
 
-  public cafeteriaDietsListCard(
-    cafeteria: Cafeteria,
-    date: Date,
-    time: DietTime,
-    diets: CafeteriaDiet[],
-  ): SkillTemplate {
+  public createCafeteriaDietListCard(result: CafeteriaDietResult): SkillTemplate {
+    const { cafeteria, date, time, diets } = result;
     const title = `🍱 ${cafeteria.name}(${cafeteria.campus.name.slice(0, 2)})`;
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
@@ -105,7 +104,7 @@ export class CafeteriaMessagesService {
     };
   }
 
-  private createDishDateQuickReplies(cafeteria: Cafeteria): QuickReply[] {
+  private createDishDateQuickReplies(cafeteria: CafeteriaItemResult): QuickReply[] {
     const dishDateTypes: DietDate[] = ['오늘', '내일'];
     const times: DietTime[] = ['아침', '점심', '저녁'];
 

--- a/services/api/app/src/api/public/cafeterias/cafeterias.controller.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.controller.ts
@@ -6,9 +6,9 @@ import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { ListCafeteriaDietExtraRequestDto } from 'src/api/public/cafeterias/dtos/requests/list-cafeteria-diet-request.dto';
 import { ListCafeteriaRequestDto } from 'src/api/public/cafeterias/dtos/requests/list-cafeteria-request.dto';
-import { CafeteriaMessagesService } from 'src/api/public/cafeterias/cafeteria-messages.service';
+import { CafeteriaMessageFactory } from 'src/api/public/cafeterias/cafeteria-message.factory';
 import { CampusesService } from 'src/api/public/campuses/campuses.service';
-import { CampusMessagesService } from 'src/api/public/campuses/campus-messages.service';
+import { CampusMessageFactory } from 'src/api/public/campuses/campus-message.factory';
 import { CurrentUser } from 'src/api/public/users/decorators/current-user.decorator';
 import { FetchCurrentUser } from 'src/api/public/users/decorators/fetch-current-user.decorator';
 import { BlockId } from 'src/api/common/utils/constants';
@@ -23,9 +23,9 @@ import { CafeteriasService } from './cafeterias.service';
 export class CafeteriasController {
   constructor(
     private readonly cafeteriasService: CafeteriasService,
-    private readonly cafeteriaMessagesService: CafeteriaMessagesService,
+    private readonly cafeteriaMessageFactory: CafeteriaMessageFactory,
     private readonly campusesService: CampusesService,
-    private readonly campusMessagesService: CampusMessagesService,
+    private readonly campusMessageFactory: CampusMessageFactory,
   ) {}
 
   @Post()
@@ -41,8 +41,8 @@ export class CafeteriasController {
     // '더보기' 버튼 또는 캠퍼스 미설정 → 캠퍼스 선택 카드 반환
     if (requestedCampusId === -1 || (!requestedCampusId && !userCampusId)) {
       const result = await this.campusesService.findAll();
-      const template = this.campusMessagesService.createCampusListCard(
-        result.campuses,
+      const template = this.campusMessageFactory.createCampusListCard(
+        result,
         BlockId.CAFETERIA_LIST,
       );
       return new ResponseDTO(template);
@@ -50,7 +50,7 @@ export class CafeteriasController {
 
     const campusId = requestedCampusId ?? userCampusId;
     const result = await this.cafeteriasService.getCafeterias(campusId);
-    const template = this.cafeteriaMessagesService.cafeteriasListCard(result.cafeterias);
+    const template = this.cafeteriaMessageFactory.createCafeteriaListCard(result);
     return new ResponseDTO(template);
   }
 
@@ -62,12 +62,7 @@ export class CafeteriasController {
   ) {
     const { cafeteriaId, date, time } = extra;
     const result = await this.cafeteriasService.getCafeteriaDiet(cafeteriaId, date, time);
-    const template = this.cafeteriaMessagesService.cafeteriaDietsListCard(
-      result.cafeteria,
-      result.date,
-      result.time,
-      result.diets,
-    );
+    const template = this.cafeteriaMessageFactory.createCafeteriaDietListCard(result);
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/cafeterias/cafeterias.module.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { CafeteriaMessagesService } from 'src/api/public/cafeterias/cafeteria-messages.service';
+import { CafeteriaMessageFactory } from 'src/api/public/cafeterias/cafeteria-message.factory';
 import { CampusesModule } from 'src/api/public/campuses/campuses.module';
-import { CampusMessagesService } from 'src/api/public/campuses/campus-messages.service';
+import { CampusMessageFactory } from 'src/api/public/campuses/campus-message.factory';
 import { CafeteriasRepositoryModule } from 'src/type-orm/entities/cafeterias/cafeterias-repository.module';
 import { CafeteriasNativeController } from './cafeterias-native.controller';
 import { CafeteriasController } from './cafeterias.controller';
@@ -10,7 +10,7 @@ import { CafeteriasService } from './cafeterias.service';
 @Module({
   imports: [CampusesModule, CafeteriasRepositoryModule],
   controllers: [CafeteriasController, CafeteriasNativeController],
-  providers: [CafeteriasService, CafeteriaMessagesService, CampusMessagesService],
+  providers: [CafeteriasService, CafeteriaMessageFactory, CampusMessageFactory],
   exports: [CafeteriasService],
 })
 export class CafeteriasModule {}

--- a/services/api/app/src/api/public/cafeterias/cafeterias.service.spec.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.service.spec.ts
@@ -11,7 +11,7 @@ const makeCafeteria = (overrides: Partial<Cafeteria> = {}): Cafeteria =>
     id: 1,
     name: '제1학생회관',
     thumbnailUrl: 'https://example.com/thumb.jpg',
-    campus: { id: 1, name: '가좌캠퍼스' },
+    campus: { id: 1, name: '가좌캠퍼스', thumbnailUrl: 'https://example.com/campus.jpg' },
     ...overrides,
   } as Cafeteria);
 
@@ -55,7 +55,18 @@ describe('CafeteriasService', () => {
       const result = await service.getCafeterias(1);
 
       expect(cafeteriasRepository.findCafeteriasByCampusId).toHaveBeenCalledWith(1);
-      expect(result.cafeterias).toBe(cafeterias);
+      expect(result.cafeterias).toEqual([
+        {
+          id: 1,
+          name: '제1학생회관',
+          thumbnailUrl: 'https://example.com/thumb.jpg',
+          campus: {
+            id: 1,
+            name: '가좌캠퍼스',
+            thumbnailUrl: 'https://example.com/campus.jpg',
+          },
+        },
+      ]);
     });
 
     it('cache hit이면 DB 조회 없이 캐시 값을 반환한다', async () => {
@@ -86,8 +97,23 @@ describe('CafeteriasService', () => {
 
       const result = await service.getCafeteriaDiet(5, '오늘', '점심');
 
-      expect(result.cafeteria).toBe(cafeteria);
-      expect(result.diets).toBe(diets);
+      expect(result.cafeteria).toEqual({
+        id: 5,
+        name: '제1학생회관',
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        campus: {
+          id: 1,
+          name: '가좌캠퍼스',
+          thumbnailUrl: 'https://example.com/campus.jpg',
+        },
+      });
+      expect(result.diets).toEqual([
+        {
+          dishName: '김치찌개',
+          dishCategory: '한식',
+          dishType: '국',
+        },
+      ]);
       expect(result.time).toBe('점심');
       expect(result.date).toBeInstanceOf(Date);
     });

--- a/services/api/app/src/api/public/cafeterias/cafeterias.service.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.service.ts
@@ -27,7 +27,18 @@ export class CafeteriasService {
   })
   public async getCafeterias(campusId: number): Promise<CafeteriaListResult> {
     const cafeterias = await this.cafeteriasRepository.findCafeteriasByCampusId(campusId);
-    return { cafeterias };
+    return {
+      cafeterias: cafeterias.map(cafeteria => ({
+        id: cafeteria.id,
+        name: cafeteria.name,
+        thumbnailUrl: cafeteria.thumbnailUrl,
+        campus: {
+          id: cafeteria.campus.id,
+          name: cafeteria.campus.name,
+          thumbnailUrl: cafeteria.campus.thumbnailUrl,
+        },
+      })),
+    };
   }
 
   /**
@@ -52,7 +63,25 @@ export class CafeteriasService {
       resolvedTime,
     );
 
-    return { cafeteria, diets, date, time: resolvedTime };
+    return {
+      cafeteria: {
+        id: cafeteria.id,
+        name: cafeteria.name,
+        thumbnailUrl: cafeteria.thumbnailUrl,
+        campus: {
+          id: cafeteria.campus.id,
+          name: cafeteria.campus.name,
+          thumbnailUrl: cafeteria.campus.thumbnailUrl,
+        },
+      },
+      diets: diets.map(diet => ({
+        dishCategory: diet.dishCategory,
+        dishType: diet.dishType,
+        dishName: diet.dishName,
+      })),
+      date,
+      time: resolvedTime,
+    };
   }
 
   /**
@@ -85,6 +114,24 @@ export class CafeteriasService {
       time,
     );
 
-    return { cafeteria, diets, date, time };
+    return {
+      cafeteria: {
+        id: cafeteria.id,
+        name: cafeteria.name,
+        thumbnailUrl: cafeteria.thumbnailUrl,
+        campus: {
+          id: cafeteria.campus.id,
+          name: cafeteria.campus.name,
+          thumbnailUrl: cafeteria.campus.thumbnailUrl,
+        },
+      },
+      diets: diets.map(diet => ({
+        dishCategory: diet.dishCategory,
+        dishType: diet.dishType,
+        dishName: diet.dishName,
+      })),
+      date,
+      time,
+    };
   }
 }

--- a/services/api/app/src/api/public/cafeterias/dtos/results/cafeteria-diet-result.dto.ts
+++ b/services/api/app/src/api/public/cafeterias/dtos/results/cafeteria-diet-result.dto.ts
@@ -1,10 +1,15 @@
 import { DietTime } from 'src/api/public/cafeterias/dtos/requests/list-cafeteria-diet-request.dto';
-import { CafeteriaDiet } from 'src/type-orm/entities/cafeterias/cafeteria-diet.entity';
-import { Cafeteria } from 'src/type-orm/entities/cafeterias/cafeteria.entity';
+import { CafeteriaItemResult } from 'src/api/public/cafeterias/dtos/results/cafeteria-list-result.dto';
+
+export interface CafeteriaDietItemResult {
+  dishCategory: string | null;
+  dishType: string | null;
+  dishName: string;
+}
 
 export interface CafeteriaDietResult {
-  cafeteria: Cafeteria;
-  diets: CafeteriaDiet[];
+  cafeteria: CafeteriaItemResult;
+  diets: CafeteriaDietItemResult[];
   date: Date;
   time: DietTime;
 }

--- a/services/api/app/src/api/public/cafeterias/dtos/results/cafeteria-list-result.dto.ts
+++ b/services/api/app/src/api/public/cafeterias/dtos/results/cafeteria-list-result.dto.ts
@@ -1,5 +1,12 @@
-import { Cafeteria } from 'src/type-orm/entities/cafeterias/cafeteria.entity';
+import { CampusItemResult } from 'src/api/public/campuses/dtos/results/campus-list-result.dto';
+
+export interface CafeteriaItemResult {
+  id: number;
+  name: string;
+  thumbnailUrl: string;
+  campus: CampusItemResult;
+}
 
 export interface CafeteriaListResult {
-  cafeterias: Cafeteria[];
+  cafeterias: CafeteriaItemResult[];
 }

--- a/services/api/app/src/api/public/campuses/campus-message.factory.ts
+++ b/services/api/app/src/api/public/campuses/campus-message.factory.ts
@@ -3,16 +3,16 @@ import { ListCard } from 'src/api/common/interfaces/response/fields/component';
 import { ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard } from 'src/api/common/utils/component';
-import { Campus } from 'src/type-orm/entities/campuses/campus.entity';
+import { CampusListResult } from 'src/api/public/campuses/dtos/results/campus-list-result.dto';
 
 @Injectable()
-export class CampusMessagesService {
-  createCampusListCard(campuses: Campus[], blockId: string): SkillTemplate {
+export class CampusMessageFactory {
+  createCampusListCard(result: CampusListResult, blockId: string): SkillTemplate {
     const header: ListItem = {
       title: '캠퍼스 선택',
     };
 
-    const items: ListItem[] = campuses.map(campus => ({
+    const items: ListItem[] = result.campuses.map(campus => ({
       title: campus.name,
       imageUrl: campus.thumbnailUrl,
       action: 'block',

--- a/services/api/app/src/api/public/campuses/campuses.service.ts
+++ b/services/api/app/src/api/public/campuses/campuses.service.ts
@@ -18,6 +18,12 @@ export class CampusesService {
   })
   public async findAll(): Promise<CampusListResult> {
     const campuses = await this.campusesRepository.findAll();
-    return { campuses };
+    return {
+      campuses: campuses.map(campus => ({
+        id: campus.id,
+        name: campus.name,
+        thumbnailUrl: campus.thumbnailUrl,
+      })),
+    };
   }
 }

--- a/services/api/app/src/api/public/campuses/dtos/results/campus-list-result.dto.ts
+++ b/services/api/app/src/api/public/campuses/dtos/results/campus-list-result.dto.ts
@@ -1,5 +1,9 @@
-import { Campus } from 'src/type-orm/entities/campuses/campus.entity';
+export interface CampusItemResult {
+  id: number;
+  name: string;
+  thumbnailUrl: string;
+}
 
 export interface CampusListResult {
-  campuses: Campus[];
+  campuses: CampusItemResult[];
 }

--- a/services/api/app/src/api/public/colleges/college-message.factory.ts
+++ b/services/api/app/src/api/public/colleges/college-message.factory.ts
@@ -4,13 +4,12 @@ import { ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard } from 'src/api/common/utils/component';
 import { BlockId, ListCardConfig } from 'src/api/common/utils/constants';
-import { College } from 'src/type-orm/entities/colleges/college.entity';
+import { CollegeListResult } from 'src/api/public/colleges/dtos/results/college-list-result.dto';
 
 @Injectable()
-export class CollegeMessagesService {
-  public collegesListCard(
-    colleges: College[],
-    total: number,
+export class CollegeMessageFactory {
+  public createCollegeListCard(
+    result: CollegeListResult,
     campusId: number,
     page: number,
     blockId: string,
@@ -19,7 +18,7 @@ export class CollegeMessagesService {
       title: '단과대학 선택',
     };
 
-    const items: ListItem[] = colleges.map(college => {
+    const items: ListItem[] = result.colleges.map(college => {
       return {
         title: college.name,
         imageUrl: college.thumbnailUrl,
@@ -34,7 +33,7 @@ export class CollegeMessagesService {
 
     const collegeListCard: ListCard = createListCard(header, items);
 
-    const totalPages = Math.ceil(total / ListCardConfig.LIMIT);
+    const totalPages = Math.ceil(result.total / ListCardConfig.LIMIT);
     const paginationButtons = [];
 
     if (page > 1) {

--- a/services/api/app/src/api/public/colleges/colleges.service.ts
+++ b/services/api/app/src/api/public/colleges/colleges.service.ts
@@ -18,6 +18,13 @@ export class CollegesService {
   })
   public async findAll(page: number): Promise<CollegeListResult> {
     const [colleges, total] = await this.collegesRepository.findAll(page);
-    return { colleges, total };
+    return {
+      colleges: colleges.map(college => ({
+        id: college.id,
+        name: college.name,
+        thumbnailUrl: college.thumbnailUrl,
+      })),
+      total,
+    };
   }
 }

--- a/services/api/app/src/api/public/colleges/dtos/results/college-list-result.dto.ts
+++ b/services/api/app/src/api/public/colleges/dtos/results/college-list-result.dto.ts
@@ -1,6 +1,10 @@
-import { College } from 'src/type-orm/entities/colleges/college.entity';
+export interface CollegeItemResult {
+  id: number;
+  name: string;
+  thumbnailUrl: string;
+}
 
 export interface CollegeListResult {
-  colleges: College[];
+  colleges: CollegeItemResult[];
   total: number;
 }

--- a/services/api/app/src/api/public/common/common-message.factory.ts
+++ b/services/api/app/src/api/public/common/common-message.factory.ts
@@ -6,7 +6,7 @@ import { createSimpleText, createTextCard } from 'src/api/common/utils/component
 import { BlockId } from 'src/api/common/utils/constants';
 
 @Injectable()
-export class CommonMessagesService {
+export class CommonMessageFactory {
   createSimpleText(text: string): SkillTemplate {
     return {
       outputs: [createSimpleText(text)],

--- a/services/api/app/src/api/public/departments/department-message.factory.ts
+++ b/services/api/app/src/api/public/departments/department-message.factory.ts
@@ -4,22 +4,21 @@ import { ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard } from 'src/api/common/utils/component';
 import { BlockId, ListCardConfig } from 'src/api/common/utils/constants';
+import { DepartmentListResult } from 'src/api/public/departments/dtos/results/department-list-result.dto';
 import { ListDepartmentsRequestDto } from 'src/api/public/users/dtos/requests/list-department-request.dto';
-import { Department } from 'src/type-orm/entities/departments/department.entity';
 
 @Injectable()
-export class DepartmentMessagesService {
-  public async departmentsListCard(
-    departments: Department[],
-    total: number,
+export class DepartmentMessageFactory {
+  public createDepartmentListCard(
+    result: DepartmentListResult,
     extra: ListDepartmentsRequestDto,
     blockId: string,
-  ): Promise<SkillTemplate> {
+  ): SkillTemplate {
     const header: ListItem = {
       title: '학과 선택',
     };
 
-    const items: ListItem[] = departments.map(department => {
+    const items: ListItem[] = result.departments.map(department => {
       return {
         title: department.name,
         action: 'block',
@@ -33,7 +32,7 @@ export class DepartmentMessagesService {
 
     const departmentListCard: ListCard = createListCard(header, items);
 
-    const totalPages = Math.ceil(total / ListCardConfig.LIMIT);
+    const totalPages = Math.ceil(result.total / ListCardConfig.LIMIT);
     const paginationButtons = [];
 
     if (extra.page > 1) {

--- a/services/api/app/src/api/public/departments/departments.service.ts
+++ b/services/api/app/src/api/public/departments/departments.service.ts
@@ -20,6 +20,12 @@ export class DepartmentsService {
   })
   public async findAll(collegeId: number, page: number): Promise<DepartmentListResult> {
     const [departments, total] = await this.departmentsRepository.findByCollegeId(collegeId, page);
-    return { departments, total };
+    return {
+      departments: departments.map(department => ({
+        id: department.id,
+        name: department.name,
+      })),
+      total,
+    };
   }
 }

--- a/services/api/app/src/api/public/departments/dtos/results/department-list-result.dto.ts
+++ b/services/api/app/src/api/public/departments/dtos/results/department-list-result.dto.ts
@@ -1,6 +1,9 @@
-import { Department } from 'src/type-orm/entities/departments/department.entity';
+export interface DepartmentItemResult {
+  id: number;
+  name: string;
+}
 
 export interface DepartmentListResult {
-  departments: Department[];
+  departments: DepartmentItemResult[];
   total: number;
 }

--- a/services/api/app/src/api/public/notices/dtos/results/notice-list-result.dto.ts
+++ b/services/api/app/src/api/public/notices/dtos/results/notice-list-result.dto.ts
@@ -1,6 +1,18 @@
-import { NoticeCategory } from 'src/type-orm/entities/notices/notice-category.entity';
-import { Notice } from 'src/type-orm/entities/notices/notice.entity';
+export interface NoticeItemResult {
+  title: string;
+  nttSn: number;
+  createdAt: Date;
+}
+
+export interface NoticeCategoryResult {
+  category: string;
+  mi: number;
+  bbsId: number;
+  departmentName?: string;
+  departmentEn?: string;
+  notices: NoticeItemResult[];
+}
 
 export interface NoticeListResult {
-  noticesMap: Map<NoticeCategory, Notice[]>;
+  categories: NoticeCategoryResult[];
 }

--- a/services/api/app/src/api/public/notices/notice-message.factory.spec.ts
+++ b/services/api/app/src/api/public/notices/notice-message.factory.spec.ts
@@ -1,55 +1,48 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NoticeMessagesService } from 'src/api/public/notices/notice-messages.service';
-import { NoticeCategory } from 'src/type-orm/entities/notices/notice-category.entity';
-import { Notice } from 'src/type-orm/entities/notices/notice.entity';
+import { NoticeMessageFactory } from 'src/api/public/notices/notice-message.factory';
+import {
+  NoticeCategoryResult,
+  NoticeItemResult,
+  NoticeListResult,
+} from 'src/api/public/notices/dtos/results/notice-list-result.dto';
 
-const makeCategory = (overrides: Partial<NoticeCategory> = {}): NoticeCategory =>
-  ({
-    id: 1,
-    departmentId: 117,
-    category: '학사',
-    mi: 100,
-    bbsId: 200,
-    lastNttSn: 0,
-    updatedAt: new Date(),
-    department: {
-      id: 1,
-      name: '컴퓨터공학부',
-      departmentEn: 'cse',
-      parentDepartmentId: null,
-    },
-    notices: [],
-    ...overrides,
-  } as NoticeCategory);
+const makeCategory = (overrides: Partial<NoticeCategoryResult> = {}): NoticeCategoryResult => ({
+  category: '학사',
+  mi: 100,
+  bbsId: 200,
+  departmentName: '컴퓨터공학부',
+  departmentEn: 'cse',
+  notices: [],
+  ...overrides,
+});
 
-const makeNotice = (overrides: Partial<Notice> = {}): Notice =>
-  ({
-    id: 1,
-    categoryId: 1,
-    title: '2024학년도 수강신청 안내',
-    nttSn: 12345,
-    createdAt: new Date('2024-06-01'),
-    ...overrides,
-  } as Notice);
+const makeNotice = (overrides: Partial<NoticeItemResult> = {}): NoticeItemResult => ({
+  title: '2024학년도 수강신청 안내',
+  nttSn: 12345,
+  createdAt: new Date('2024-06-01'),
+  ...overrides,
+});
 
-describe('NoticeMessagesService', () => {
-  let service: NoticeMessagesService;
+const makeResult = (categories: NoticeCategoryResult[]): NoticeListResult => ({ categories });
+
+describe('NoticeMessageFactory', () => {
+  let service: NoticeMessageFactory;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NoticeMessagesService],
+      providers: [NoticeMessageFactory],
     }).compile();
 
-    service = module.get<NoticeMessagesService>(NoticeMessagesService);
+    service = module.get<NoticeMessageFactory>(NoticeMessageFactory);
   });
 
   describe('createUniversityNoticeCarousel', () => {
     it('캐러셀 타입의 SkillTemplate을 반환한다', () => {
       const category = makeCategory();
       const notice = makeNotice();
-      const map = new Map([[category, [notice]]]);
+      const noticeResult = makeResult([{ ...category, notices: [notice] }]);
 
-      const result = service.createUniversityNoticeCarousel(map);
+      const result = service.createUniversityNoticeCarousel(noticeResult);
 
       expect(result.outputs).toHaveLength(1);
       expect(result.outputs[0]).toHaveProperty('carousel');
@@ -57,14 +50,10 @@ describe('NoticeMessagesService', () => {
     });
 
     it('카테고리마다 ListCard 하나씩 생성한다', () => {
-      const cat1 = makeCategory({ id: 1, category: '학사' });
-      const cat2 = makeCategory({ id: 2, category: '장학' });
-      const map = new Map([
-        [cat1, [makeNotice({ id: 1 })]],
-        [cat2, [makeNotice({ id: 2 })]],
-      ]);
+      const cat1 = makeCategory({ category: '학사', notices: [makeNotice()] });
+      const cat2 = makeCategory({ category: '장학', notices: [makeNotice()] });
 
-      const result = service.createUniversityNoticeCarousel(map);
+      const result = service.createUniversityNoticeCarousel(makeResult([cat1, cat2]));
       const items = (result.outputs[0] as any).carousel.items;
 
       expect(items).toHaveLength(2);
@@ -72,9 +61,10 @@ describe('NoticeMessagesService', () => {
 
     it('카드 헤더 타이틀이 "${category} 공지" 형식이다', () => {
       const category = makeCategory({ category: '학사' });
-      const map = new Map([[category, [makeNotice()]]]);
 
-      const result = service.createUniversityNoticeCarousel(map);
+      const result = service.createUniversityNoticeCarousel(
+        makeResult([{ ...category, notices: [makeNotice()] }]),
+      );
       const header = (result.outputs[0] as any).carousel.items[0].header;
 
       expect(header.title).toBe('학사 공지');
@@ -83,9 +73,10 @@ describe('NoticeMessagesService', () => {
     it('공지 항목의 링크 URL이 학교 공지 URL 형식을 따른다', () => {
       const category = makeCategory({ mi: 100, bbsId: 200 });
       const notice = makeNotice({ nttSn: 12345 });
-      const map = new Map([[category, [notice]]]);
 
-      const result = service.createUniversityNoticeCarousel(map);
+      const result = service.createUniversityNoticeCarousel(
+        makeResult([{ ...category, notices: [notice] }]),
+      );
       const item = (result.outputs[0] as any).carousel.items[0].items[0];
 
       expect(item.link.web).toBe(
@@ -96,9 +87,10 @@ describe('NoticeMessagesService', () => {
     it('공지 날짜를 YYYY-MM-DD 형식으로 포맷팅한다', () => {
       const category = makeCategory();
       const notice = makeNotice({ createdAt: new Date('2024-03-05') });
-      const map = new Map([[category, [notice]]]);
 
-      const result = service.createUniversityNoticeCarousel(map);
+      const result = service.createUniversityNoticeCarousel(
+        makeResult([{ ...category, notices: [notice] }]),
+      );
       const item = (result.outputs[0] as any).carousel.items[0].items[0];
 
       expect(item.description).toMatch(/^\d{4}-\d{2}-\d{2}$/);
@@ -107,9 +99,10 @@ describe('NoticeMessagesService', () => {
     it('공지 제목이 항목 title에 포함된다', () => {
       const category = makeCategory();
       const notice = makeNotice({ title: '2024학년도 수강신청 안내' });
-      const map = new Map([[category, [notice]]]);
 
-      const result = service.createUniversityNoticeCarousel(map);
+      const result = service.createUniversityNoticeCarousel(
+        makeResult([{ ...category, notices: [notice] }]),
+      );
       const item = (result.outputs[0] as any).carousel.items[0].items[0];
 
       expect(item.title).toBe('2024학년도 수강신청 안내');
@@ -120,9 +113,10 @@ describe('NoticeMessagesService', () => {
     it('캐러셀 타입의 SkillTemplate을 반환한다', () => {
       const category = makeCategory();
       const notice = makeNotice();
-      const map = new Map([[category, [notice]]]);
 
-      const result = service.createDepartmentNoticeCarousel(map);
+      const result = service.createDepartmentNoticeCarousel(
+        makeResult([{ ...category, notices: [notice] }]),
+      );
 
       expect(result.outputs).toHaveLength(1);
       expect((result.outputs[0] as any).carousel.type).toBe('listCard');
@@ -131,16 +125,12 @@ describe('NoticeMessagesService', () => {
     it('카드 헤더 타이틀이 "${학과명} - ${카테고리}" 형식이다', () => {
       const category = makeCategory({
         category: '공지',
-        department: {
-          id: 1,
-          name: '컴퓨터공학부',
-          departmentEn: 'cse',
-          parentDepartmentId: null,
-        } as any,
+        departmentName: '컴퓨터공학부',
+        departmentEn: 'cse',
+        notices: [makeNotice()],
       });
-      const map = new Map([[category, [makeNotice()]]]);
 
-      const result = service.createDepartmentNoticeCarousel(map);
+      const result = service.createDepartmentNoticeCarousel(makeResult([category]));
       const header = (result.outputs[0] as any).carousel.items[0].header;
 
       expect(header.title).toBe('컴퓨터공학부 - 공지');
@@ -150,17 +140,12 @@ describe('NoticeMessagesService', () => {
       const category = makeCategory({
         mi: 300,
         bbsId: 400,
-        department: {
-          id: 1,
-          name: '컴퓨터공학부',
-          departmentEn: 'cse',
-          parentDepartmentId: null,
-        } as any,
       });
       const notice = makeNotice({ nttSn: 99 });
-      const map = new Map([[category, [notice]]]);
 
-      const result = service.createDepartmentNoticeCarousel(map);
+      const result = service.createDepartmentNoticeCarousel(
+        makeResult([{ ...category, notices: [notice] }]),
+      );
       const item = (result.outputs[0] as any).carousel.items[0].items[0];
 
       expect(item.link.web).toBe(
@@ -172,16 +157,10 @@ describe('NoticeMessagesService', () => {
       const category = makeCategory({
         mi: 300,
         bbsId: 400,
-        department: {
-          id: 1,
-          name: '컴퓨터공학부',
-          departmentEn: 'cse',
-          parentDepartmentId: null,
-        } as any,
+        notices: [makeNotice()],
       });
-      const map = new Map([[category, [makeNotice()]]]);
 
-      const result = service.createDepartmentNoticeCarousel(map);
+      const result = service.createDepartmentNoticeCarousel(makeResult([category]));
       const buttons = (result.outputs[0] as any).carousel.items[0].buttons;
 
       expect(buttons).toHaveLength(1);

--- a/services/api/app/src/api/public/notices/notice-message.factory.ts
+++ b/services/api/app/src/api/public/notices/notice-message.factory.ts
@@ -2,25 +2,27 @@ import { Injectable } from '@nestjs/common';
 import { Carousel, ListCard } from 'src/api/common/interfaces/response/fields/component';
 import { ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
-import { NoticeCategory } from 'src/type-orm/entities/notices/notice-category.entity';
-import { Notice } from 'src/type-orm/entities/notices/notice.entity';
+import {
+  NoticeCategoryResult,
+  NoticeListResult,
+} from 'src/api/public/notices/dtos/results/notice-list-result.dto';
 
 @Injectable()
-export class NoticeMessagesService {
+export class NoticeMessageFactory {
   /**
    * 학교 공지사항 캐러셀 생성
-   * @param noticesByCategory 카테고리별 공지사항 Map
+   * @param result 카테고리별 공지사항 목록
    * @returns SkillTemplate (캐러셀 형태의 여러 ListCard)
    */
-  createUniversityNoticeCarousel(noticesByCategory: Map<NoticeCategory, Notice[]>): SkillTemplate {
+  createUniversityNoticeCarousel(result: NoticeListResult): SkillTemplate {
     const carouselItems: ListCard['listCard'][] = [];
 
-    for (const [category, notices] of noticesByCategory) {
+    for (const category of result.categories) {
       const header: ListItem = {
         title: `${category.category} 공지`,
       };
 
-      const items: ListItem[] = notices.map(notice => ({
+      const items: ListItem[] = category.notices.map(notice => ({
         title: notice.title,
         description: this.formatNoticeDate(notice.createdAt),
         link: {
@@ -48,23 +50,25 @@ export class NoticeMessagesService {
 
   /**
    * 학과 공지사항 캐러셀 생성
-   * @param noticesByCategory 카테고리별 공지사항 Map (department relation 포함)
+   * @param result 카테고리별 공지사항 목록
    * @returns SkillTemplate (캐러셀 형태의 여러 ListCard)
    */
-  createDepartmentNoticeCarousel(noticesByCategory: Map<NoticeCategory, Notice[]>): SkillTemplate {
+  createDepartmentNoticeCarousel(result: NoticeListResult): SkillTemplate {
     const carouselItems: ListCard['listCard'][] = [];
 
-    for (const [category, notices] of noticesByCategory) {
+    for (const category of result.categories) {
+      const departmentName = this.requireDepartmentField(category, 'departmentName');
+      const departmentEn = this.requireDepartmentField(category, 'departmentEn');
       const header: ListItem = {
-        title: `${category.department.name} - ${category.category}`,
+        title: `${departmentName} - ${category.category}`,
       };
 
-      const items: ListItem[] = notices.map(notice => ({
+      const items: ListItem[] = category.notices.map(notice => ({
         title: notice.title,
         description: this.formatNoticeDate(notice.createdAt),
         link: {
           web: this.createDepartmentNoticeLinkUrl(
-            category.department.departmentEn,
+            departmentEn,
             category.mi,
             category.bbsId,
             notice.nttSn,
@@ -76,11 +80,7 @@ export class NoticeMessagesService {
         {
           label: '더보기',
           action: 'webLink' as const,
-          webLinkUrl: this.createNoticeBoardListUrl(
-            category.department.departmentEn,
-            category.mi,
-            category.bbsId,
-          ),
+          webLinkUrl: this.createNoticeBoardListUrl(departmentEn, category.mi, category.bbsId),
         },
       ];
 
@@ -140,6 +140,17 @@ export class NoticeMessagesService {
    */
   private createNoticeBoardListUrl(departmentEn: string, mi: number, bbsId: number): string {
     return `https://www.gnu.ac.kr/${departmentEn}/na/ntt/selectNttList.do?mi=${mi}&bbsId=${bbsId}`;
+  }
+
+  private requireDepartmentField(
+    category: NoticeCategoryResult,
+    field: 'departmentName' | 'departmentEn',
+  ): string {
+    const value = category[field];
+    if (!value) {
+      throw new Error(`학과 공지사항 카테고리에 ${field} 값이 없습니다.`);
+    }
+    return value;
   }
 
   /**

--- a/services/api/app/src/api/public/notices/notices.controller.ts
+++ b/services/api/app/src/api/public/notices/notices.controller.ts
@@ -3,8 +3,8 @@ import { ApiTags } from '@nestjs/swagger';
 import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
-import { CommonMessagesService } from 'src/api/public/common/common-messages.service';
-import { NoticeMessagesService } from 'src/api/public/notices/notice-messages.service';
+import { CommonMessageFactory } from 'src/api/public/common/common-message.factory';
+import { NoticeMessageFactory } from 'src/api/public/notices/notice-message.factory';
 import { CurrentUser } from 'src/api/public/users/decorators/current-user.decorator';
 import { FetchCurrentUser } from 'src/api/public/users/decorators/fetch-current-user.decorator';
 import { User } from 'src/type-orm/entities/users/users.entity';
@@ -20,8 +20,8 @@ import { NoticesService } from './notices.service';
 export class NoticesController {
   constructor(
     private readonly noticesService: NoticesService,
-    private readonly noticeMessagesService: NoticeMessagesService,
-    private readonly commonMessagesService: CommonMessagesService,
+    private readonly noticeMessageFactory: NoticeMessageFactory,
+    private readonly commonMessageFactory: CommonMessageFactory,
   ) {}
 
   @Post('university')
@@ -29,12 +29,12 @@ export class NoticesController {
   async listUniversityNotices() {
     const result = await this.noticesService.getUniversityNotices();
 
-    if (result.noticesMap.size === 0) {
-      const template = this.commonMessagesService.createSimpleText('현재 등록된 공지사항이 없어!');
+    if (result.categories.length === 0) {
+      const template = this.commonMessageFactory.createSimpleText('현재 등록된 공지사항이 없어!');
       return new ResponseDTO(template);
     }
 
-    const template = this.noticeMessagesService.createUniversityNoticeCarousel(result.noticesMap);
+    const template = this.noticeMessageFactory.createUniversityNoticeCarousel(result);
     return new ResponseDTO(template);
   }
 
@@ -43,18 +43,18 @@ export class NoticesController {
   @ApiSkillBody(ListDepartmentNoticeRequestDto)
   async listDepartmentNotices(@CurrentUser() user: User) {
     if (!user.department) {
-      const template = this.commonMessagesService.createDepartmentAuthRequiredMessage();
+      const template = this.commonMessageFactory.createDepartmentAuthRequiredMessage();
       return new ResponseDTO(template);
     }
 
     const result = await this.noticesService.getDepartmentNotices(user);
 
-    if (result.noticesMap.size === 0) {
-      const template = this.commonMessagesService.createSimpleText('현재 등록된 공지사항이 없어!');
+    if (result.categories.length === 0) {
+      const template = this.commonMessageFactory.createSimpleText('현재 등록된 공지사항이 없어!');
       return new ResponseDTO(template);
     }
 
-    const template = this.noticeMessagesService.createDepartmentNoticeCarousel(result.noticesMap);
+    const template = this.noticeMessageFactory.createDepartmentNoticeCarousel(result);
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/notices/notices.module.ts
+++ b/services/api/app/src/api/public/notices/notices.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { CommonMessagesService } from 'src/api/public/common/common-messages.service';
-import { NoticeMessagesService } from 'src/api/public/notices/notice-messages.service';
+import { CommonMessageFactory } from 'src/api/public/common/common-message.factory';
+import { NoticeMessageFactory } from 'src/api/public/notices/notice-message.factory';
 import { NoticesRepositoryModule } from 'src/type-orm/entities/notices/notices-repository.module';
 import { NoticesController } from './notices.controller';
 import { NoticesService } from './notices.service';
@@ -8,7 +8,7 @@ import { NoticesService } from './notices.service';
 @Module({
   imports: [NoticesRepositoryModule],
   controllers: [NoticesController],
-  providers: [NoticesService, NoticeMessagesService, CommonMessagesService],
+  providers: [NoticesService, NoticeMessageFactory, CommonMessageFactory],
   exports: [NoticesService],
 })
 export class NoticesModule {}

--- a/services/api/app/src/api/public/notices/notices.service.spec.ts
+++ b/services/api/app/src/api/public/notices/notices.service.spec.ts
@@ -74,25 +74,25 @@ describe('NoticesService', () => {
   });
 
   describe('getUniversityNotices', () => {
-    it('카테고리가 없으면 빈 Map을 반환한다', async () => {
+    it('카테고리가 없으면 빈 목록을 반환한다', async () => {
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([]);
 
       const result = await service.getUniversityNotices();
 
-      expect(result.noticesMap.size).toBe(0);
+      expect(result.categories).toHaveLength(0);
     });
 
-    it('공지사항이 없으면 빈 Map을 반환한다', async () => {
+    it('공지사항이 없으면 빈 목록을 반환한다', async () => {
       const category = makeCategory({ id: 1, category: '학사' });
       noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([category]);
       noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
 
       const result = await service.getUniversityNotices();
 
-      expect(result.noticesMap.size).toBe(0);
+      expect(result.categories).toHaveLength(0);
     });
 
-    it('공지가 있으면 카테고리-공지 Map을 반환한다', async () => {
+    it('공지가 있으면 카테고리별 공지 목록을 반환한다', async () => {
       const category = makeCategory({ id: 1, category: '학사' });
       const notice = makeNotice({ categoryId: 1 });
       const noticeMap = new Map([[1, [notice]]]);
@@ -102,9 +102,22 @@ describe('NoticesService', () => {
 
       const result = await service.getUniversityNotices();
 
-      expect(result.noticesMap.size).toBe(1);
-      expect([...result.noticesMap.keys()][0]).toBe(category);
-      expect([...result.noticesMap.values()][0]).toEqual([notice]);
+      expect(result.categories).toEqual([
+        {
+          category: category.category,
+          mi: category.mi,
+          bbsId: category.bbsId,
+          departmentName: category.department.name,
+          departmentEn: category.department.departmentEn,
+          notices: [
+            {
+              title: notice.title,
+              nttSn: notice.nttSn,
+              createdAt: notice.createdAt,
+            },
+          ],
+        },
+      ]);
     });
 
     it('TARGET_CATEGORIES 순서대로 Map이 구성된다', async () => {
@@ -121,7 +134,7 @@ describe('NoticesService', () => {
 
       const result = await service.getUniversityNotices();
 
-      const keys = [...result.noticesMap.keys()].map(c => c.category);
+      const keys = result.categories.map(c => c.category);
       expect(keys).toEqual(TARGET_CATEGORIES);
     });
 
@@ -138,8 +151,8 @@ describe('NoticesService', () => {
 
       const result = await service.getUniversityNotices();
 
-      expect(result.noticesMap.size).toBe(1);
-      expect([...result.noticesMap.keys()][0].id).toBe(1);
+      expect(result.categories).toHaveLength(1);
+      expect(result.categories[0].category).toBe(catWithNotices.category);
     });
 
     it('department_id 117로 카테고리를 조회한다', async () => {
@@ -155,24 +168,24 @@ describe('NoticesService', () => {
   });
 
   describe('getDepartmentNotices', () => {
-    it('user.department가 null이면 빈 Map을 반환한다', async () => {
+    it('user.department가 null이면 빈 목록을 반환한다', async () => {
       const user = makeUser({ department: null });
 
       const result = await service.getDepartmentNotices(user);
 
-      expect(result.noticesMap.size).toBe(0);
+      expect(result.categories).toHaveLength(0);
     });
 
-    it('카테고리가 없으면 빈 Map을 반환한다', async () => {
+    it('카테고리가 없으면 빈 목록을 반환한다', async () => {
       const user = makeUser();
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([]);
 
       const result = await service.getDepartmentNotices(user);
 
-      expect(result.noticesMap.size).toBe(0);
+      expect(result.categories).toHaveLength(0);
     });
 
-    it('공지사항이 없으면 빈 Map을 반환한다', async () => {
+    it('공지사항이 없으면 빈 목록을 반환한다', async () => {
       const user = makeUser();
       const category = makeCategory({ id: 1 });
       noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([category]);
@@ -180,10 +193,10 @@ describe('NoticesService', () => {
 
       const result = await service.getDepartmentNotices(user);
 
-      expect(result.noticesMap.size).toBe(0);
+      expect(result.categories).toHaveLength(0);
     });
 
-    it('공지가 있으면 카테고리-공지 Map을 반환한다', async () => {
+    it('공지가 있으면 카테고리별 공지 목록을 반환한다', async () => {
       const user = makeUser();
       const category = makeCategory({ id: 1 });
       const noticeMap = new Map([[1, [makeNotice()]]]);
@@ -193,7 +206,7 @@ describe('NoticesService', () => {
 
       const result = await service.getDepartmentNotices(user);
 
-      expect(result.noticesMap.size).toBe(1);
+      expect(result.categories).toHaveLength(1);
     });
 
     it('parentDepartmentId가 있으면 departmentIds에 부모 학과 ID도 포함된다', async () => {

--- a/services/api/app/src/api/public/notices/notices.service.ts
+++ b/services/api/app/src/api/public/notices/notices.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { NoticeListResult } from 'src/api/public/notices/dtos/results/notice-list-result.dto';
+import {
+  NoticeCategoryResult,
+  NoticeListResult,
+} from 'src/api/public/notices/dtos/results/notice-list-result.dto';
 import { NoticeCategoriesRepository } from 'src/type-orm/entities/notices/notice-categories.repository';
 import { NoticeCategory } from 'src/type-orm/entities/notices/notice-category.entity';
 import { Notice } from 'src/type-orm/entities/notices/notice.entity';
@@ -30,7 +33,7 @@ export class NoticesService {
     );
 
     if (categories.length === 0) {
-      return { noticesMap: new Map() };
+      return { categories: [] };
     }
 
     const categoryIds = categories.map(category => category.id);
@@ -39,19 +42,19 @@ export class NoticesService {
       this.CAROUSEL_ITEMS_LIMIT,
     );
 
-    const result = new Map<NoticeCategory, Notice[]>();
+    const categoriesResult: NoticeCategoryResult[] = [];
 
     for (const targetCategory of this.TARGET_CATEGORIES) {
       const category = categories.find(c => c.category === targetCategory);
       if (category) {
         const notices = noticesByCategory.get(category.id) || [];
         if (notices.length > 0) {
-          result.set(category, notices);
+          categoriesResult.push(this.createNoticeCategoryResult(category, notices));
         }
       }
     }
 
-    return { noticesMap: result };
+    return { categories: categoriesResult };
   }
 
   /**
@@ -61,7 +64,7 @@ export class NoticesService {
    */
   async getDepartmentNotices(user: User): Promise<NoticeListResult> {
     if (!user.department) {
-      return { noticesMap: new Map() };
+      return { categories: [] };
     }
 
     const departmentIds: number[] = [user.department.id];
@@ -72,7 +75,7 @@ export class NoticesService {
     const categories = await this.noticeCategoriesRepository.findByDepartmentIds(departmentIds);
 
     if (categories.length === 0) {
-      return { noticesMap: new Map() };
+      return { categories: [] };
     }
 
     const categoryIds = categories.map(category => category.id);
@@ -81,15 +84,33 @@ export class NoticesService {
       this.CAROUSEL_ITEMS_LIMIT,
     );
 
-    const result = new Map<NoticeCategory, Notice[]>();
+    const categoriesResult: NoticeCategoryResult[] = [];
 
     for (const category of categories) {
       const notices = noticesByCategory.get(category.id) || [];
       if (notices.length > 0) {
-        result.set(category, notices);
+        categoriesResult.push(this.createNoticeCategoryResult(category, notices));
       }
     }
 
-    return { noticesMap: result };
+    return { categories: categoriesResult };
+  }
+
+  private createNoticeCategoryResult(
+    category: NoticeCategory,
+    notices: Notice[],
+  ): NoticeCategoryResult {
+    return {
+      category: category.category,
+      mi: category.mi,
+      bbsId: category.bbsId,
+      departmentName: category.department?.name,
+      departmentEn: category.department?.departmentEn,
+      notices: notices.map(notice => ({
+        title: notice.title,
+        nttSn: notice.nttSn,
+        createdAt: notice.createdAt,
+      })),
+    };
   }
 }

--- a/services/api/app/src/api/public/schedules/dtos/results/academic-schedule-result.dto.ts
+++ b/services/api/app/src/api/public/schedules/dtos/results/academic-schedule-result.dto.ts
@@ -1,7 +1,11 @@
-import { AcademicCalendar } from 'src/type-orm/entities/academic-calendars/academic-calendar.entity';
+export interface AcademicScheduleItemResult {
+  content: string;
+  startDate: Date;
+  endDate: Date;
+}
 
 export interface AcademicScheduleResult {
   year: number;
   month: number;
-  schedules: AcademicCalendar[];
+  schedules: AcademicScheduleItemResult[];
 }

--- a/services/api/app/src/api/public/schedules/schedule-message.factory.ts
+++ b/services/api/app/src/api/public/schedules/schedule-message.factory.ts
@@ -4,10 +4,10 @@ import { Button, QuickReply } from 'src/api/common/interfaces/response/fields/et
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createTextCard } from 'src/api/common/utils/component';
 import { BlockId } from 'src/api/common/utils/constants';
-import { AcademicCalendar } from 'src/type-orm/entities/academic-calendars/academic-calendar.entity';
+import { AcademicScheduleResult } from 'src/api/public/schedules/dtos/results/academic-schedule-result.dto';
 
 @Injectable()
-export class ScheduleMessagesService {
+export class ScheduleMessageFactory {
   /**
    * 학사일정 TextCard 생성
    * @param year 년도
@@ -15,19 +15,15 @@ export class ScheduleMessagesService {
    * @param schedules 학사일정 목록
    * @returns SkillTemplate
    */
-  createAcademicScheduleTextCard(
-    year: number,
-    month: number,
-    schedules: AcademicCalendar[],
-  ): SkillTemplate {
-    const title = `${year}년 ${month}월 학사일정`;
+  createAcademicScheduleTextCard(result: AcademicScheduleResult): SkillTemplate {
+    const title = `${result.year}년 ${result.month}월 학사일정`;
 
     // 학사일정 내용 생성
     let description = '';
-    if (schedules.length === 0) {
+    if (result.schedules.length === 0) {
       description = '등록된 학사일정이 없습니다.';
     } else {
-      description = schedules
+      description = result.schedules
         .map(schedule => {
           const startDate = new Date(schedule.startDate);
           const endDate = new Date(schedule.endDate);
@@ -54,7 +50,7 @@ export class ScheduleMessagesService {
     const textCard: TextCard = createTextCard(title, description, buttons);
 
     // Quick Replies 생성
-    const quickReplies = this.createMonthQuickReplies(month);
+    const quickReplies = this.createMonthQuickReplies(result.month);
 
     return {
       outputs: [textCard],

--- a/services/api/app/src/api/public/schedules/schedules.controller.ts
+++ b/services/api/app/src/api/public/schedules/schedules.controller.ts
@@ -4,8 +4,8 @@ import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator
 import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
-import { CommonMessagesService } from 'src/api/public/common/common-messages.service';
-import { ScheduleMessagesService } from 'src/api/public/schedules/schedule-messages.service';
+import { CommonMessageFactory } from 'src/api/public/common/common-message.factory';
+import { ScheduleMessageFactory } from 'src/api/public/schedules/schedule-message.factory';
 import { ListAcademicScheduleExtraDto } from './dtos/requests/list-academic-schedule-request.dto';
 import { KakaoAuthGuard } from 'src/api/public/users/guards/kakao-auth.guard';
 import { SchedulesService } from './schedules.service';
@@ -17,8 +17,8 @@ import { SchedulesService } from './schedules.service';
 export class SchedulesController {
   constructor(
     private readonly schedulesService: SchedulesService,
-    private readonly scheduleMessagesService: ScheduleMessagesService,
-    private readonly commonMessagesService: CommonMessagesService,
+    private readonly scheduleMessageFactory: ScheduleMessageFactory,
+    private readonly commonMessageFactory: CommonMessageFactory,
   ) {}
 
   @Post()
@@ -30,16 +30,12 @@ export class SchedulesController {
 
     if (month !== undefined && (month < 1 || month > 12)) {
       const template =
-        this.commonMessagesService.createSimpleText('올바른 월을 입력해주세요. (1-12)');
+        this.commonMessageFactory.createSimpleText('올바른 월을 입력해주세요. (1-12)');
       return new ResponseDTO(template);
     }
 
     const result = await this.schedulesService.getAcademicSchedules(month);
-    const template = this.scheduleMessagesService.createAcademicScheduleTextCard(
-      result.year,
-      result.month,
-      result.schedules,
-    );
+    const template = this.scheduleMessageFactory.createAcademicScheduleTextCard(result);
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/schedules/schedules.module.ts
+++ b/services/api/app/src/api/public/schedules/schedules.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { CommonMessagesService } from 'src/api/public/common/common-messages.service';
-import { ScheduleMessagesService } from 'src/api/public/schedules/schedule-messages.service';
+import { CommonMessageFactory } from 'src/api/public/common/common-message.factory';
+import { ScheduleMessageFactory } from 'src/api/public/schedules/schedule-message.factory';
 import { AcademicCalendarsRepositoryModule } from 'src/type-orm/entities/academic-calendars/academic-calendars-repository.module';
 import { SchedulesController } from 'src/api/public/schedules/schedules.controller';
 import { SchedulesService } from './schedules.service';
@@ -8,7 +8,7 @@ import { SchedulesService } from './schedules.service';
 @Module({
   imports: [AcademicCalendarsRepositoryModule],
   controllers: [SchedulesController],
-  providers: [SchedulesService, ScheduleMessagesService, CommonMessagesService],
+  providers: [SchedulesService, ScheduleMessageFactory, CommonMessageFactory],
   exports: [SchedulesService],
 })
 export class SchedulesModule {}

--- a/services/api/app/src/api/public/schedules/schedules.service.ts
+++ b/services/api/app/src/api/public/schedules/schedules.service.ts
@@ -23,6 +23,14 @@ export class SchedulesService {
       this.UNDERGRADUATE_CALENDAR_TYPE,
     );
 
-    return { year, month: targetMonth, schedules };
+    return {
+      year,
+      month: targetMonth,
+      schedules: schedules.map(schedule => ({
+        content: schedule.content,
+        startDate: schedule.startDate,
+        endDate: schedule.endDate,
+      })),
+    };
   }
 }

--- a/services/api/app/src/api/public/shuttles/dtos/results/shuttle-route-list-result.dto.ts
+++ b/services/api/app/src/api/public/shuttles/dtos/results/shuttle-route-list-result.dto.ts
@@ -1,5 +1,8 @@
-import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
+export interface ShuttleRouteResult {
+  routeName: string;
+  updatedAt: Date;
+}
 
 export interface ShuttleRouteListResult {
-  routes: ShuttleTimetable[];
+  routes: ShuttleRouteResult[];
 }

--- a/services/api/app/src/api/public/shuttles/dtos/results/shuttle-timetable-result.dto.ts
+++ b/services/api/app/src/api/public/shuttles/dtos/results/shuttle-timetable-result.dto.ts
@@ -1,5 +1,7 @@
-import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
+export type ShuttleTimetableSectionsResult = Record<string, string[]>;
 
 export interface ShuttleTimetableResult {
-  timetable: ShuttleTimetable;
+  routeName: string;
+  timetable: ShuttleTimetableSectionsResult;
+  updatedAt: Date;
 }

--- a/services/api/app/src/api/public/shuttles/shuttle-message.factory.ts
+++ b/services/api/app/src/api/public/shuttles/shuttle-message.factory.ts
@@ -3,16 +3,15 @@ import { Button, ListItem } from 'src/api/common/interfaces/response/fields/etc'
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard, createTextCard } from 'src/api/common/utils/component';
 import { BlockId } from 'src/api/common/utils/constants';
-import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
-
-type TimetableJson = Record<string, string[]>;
+import { ShuttleRouteListResult } from 'src/api/public/shuttles/dtos/results/shuttle-route-list-result.dto';
+import { ShuttleTimetableResult } from 'src/api/public/shuttles/dtos/results/shuttle-timetable-result.dto';
 
 @Injectable()
-export class ShuttleMessagesService {
-  public createRoutesListCard(routes: ShuttleTimetable[]): SkillTemplate {
+export class ShuttleMessageFactory {
+  public createRoutesListCard(result: ShuttleRouteListResult): SkillTemplate {
     const title = '🚌 셔틀버스 노선 선택';
 
-    if (routes.length === 0) {
+    if (result.routes.length === 0) {
       return {
         outputs: [createTextCard(title, '현재 등록된 노선이 없습니다.')],
       };
@@ -20,7 +19,7 @@ export class ShuttleMessagesService {
 
     const header: ListItem = { title };
 
-    const items: ListItem[] = routes.map(route => ({
+    const items: ListItem[] = result.routes.map(route => ({
       title: route.routeName,
       action: 'block',
       blockId: BlockId.SHUTTLE_TIMETABLE,
@@ -32,13 +31,10 @@ export class ShuttleMessagesService {
     };
   }
 
-  public createTimetableTextCard(record: ShuttleTimetable): SkillTemplate {
-    const timetable = record.timetable as TimetableJson;
-    const updatedAt = record.updatedAt;
-
+  public createTimetableTextCard(result: ShuttleTimetableResult): SkillTemplate {
     const descLines: string[] = [];
 
-    for (const [section, times] of Object.entries(timetable)) {
+    for (const [section, times] of Object.entries(result.timetable)) {
       descLines.push(`[${section}]`);
       for (const time of times) {
         descLines.push(time.replace(/\(금요일 미운행\)/, '❌ 금요일 미운행'));
@@ -46,7 +42,7 @@ export class ShuttleMessagesService {
       descLines.push('');
     }
 
-    const formattedDate = updatedAt.toISOString().slice(0, 16).replace('T', ' ');
+    const formattedDate = result.updatedAt.toISOString().slice(0, 16).replace('T', ' ');
     descLines.push(`ℹ️ 시간표 업데이트: ${formattedDate}`);
 
     const buttons: Button[] = [
@@ -63,7 +59,7 @@ export class ShuttleMessagesService {
     ];
 
     return {
-      outputs: [createTextCard(`🚌 ${record.routeName} 셔틀`, descLines.join('\n'), buttons)],
+      outputs: [createTextCard(`🚌 ${result.routeName} 셔틀`, descLines.join('\n'), buttons)],
     };
   }
 }

--- a/services/api/app/src/api/public/shuttles/shuttles-native.controller.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles-native.controller.ts
@@ -68,8 +68,7 @@ export class ShuttlesNativeController {
     @Param('routeName') routeName: string,
   ): Promise<NativeResponseDto<ShuttleTimetableResponseDto>> {
     const result = await this.shuttlesService.getTimetable(routeName);
-    const record = result.timetable;
-    const rawTimetable = record.timetable as Record<string, string[]>;
+    const rawTimetable = result.timetable;
 
     const nowMinutes = getKstMinutes();
     const friday = isKstFriday();
@@ -109,10 +108,10 @@ export class ShuttlesNativeController {
     }));
 
     const data: ShuttleTimetableResponseDto = {
-      routeName: record.routeName,
+      routeName: result.routeName,
       nextBus,
       sections,
-      updatedAt: formatUpdatedAt(record.updatedAt),
+      updatedAt: formatUpdatedAt(result.updatedAt),
     };
 
     return new NativeResponseDto(data);

--- a/services/api/app/src/api/public/shuttles/shuttles.controller.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.controller.ts
@@ -5,7 +5,7 @@ import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
 import { GetShuttleTimetableRequestDto } from './dtos/request/get-shuttle-timetable-request.dto';
-import { ShuttleMessagesService } from './shuttle-messages.service';
+import { ShuttleMessageFactory } from './shuttle-message.factory';
 import { KakaoAuthGuard } from 'src/api/public/users/guards/kakao-auth.guard';
 import { ShuttlesService } from './shuttles.service';
 
@@ -16,13 +16,13 @@ import { ShuttlesService } from './shuttles.service';
 export class ShuttlesController {
   constructor(
     private readonly shuttlesService: ShuttlesService,
-    private readonly shuttleMessagesService: ShuttleMessagesService,
+    private readonly shuttleMessageFactory: ShuttleMessageFactory,
   ) {}
 
   @Post('routes')
   public async getRoutesList(): Promise<ResponseDTO> {
     const result = await this.shuttlesService.getRoutes();
-    const template = this.shuttleMessagesService.createRoutesListCard(result.routes);
+    const template = this.shuttleMessageFactory.createRoutesListCard(result);
     return new ResponseDTO(template);
   }
 
@@ -33,7 +33,7 @@ export class ShuttlesController {
     extra: GetShuttleTimetableRequestDto,
   ): Promise<ResponseDTO> {
     const result = await this.shuttlesService.getTimetable(extra.routeName);
-    const template = this.shuttleMessagesService.createTimetableTextCard(result.timetable);
+    const template = this.shuttleMessageFactory.createTimetableTextCard(result);
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/shuttles/shuttles.module.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.module.ts
@@ -3,7 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from 'src/type-orm/database.module';
 import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
 import { ShuttleTimetableRepository } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.repository';
-import { ShuttleMessagesService } from './shuttle-messages.service';
+import { ShuttleMessageFactory } from './shuttle-message.factory';
 import { ShuttlesController } from './shuttles.controller';
 import { ShuttlesNativeController } from './shuttles-native.controller';
 import { ShuttlesService } from './shuttles.service';
@@ -11,6 +11,6 @@ import { ShuttlesService } from './shuttles.service';
 @Module({
   imports: [DatabaseModule, TypeOrmModule.forFeature([ShuttleTimetable])],
   controllers: [ShuttlesController, ShuttlesNativeController],
-  providers: [ShuttlesService, ShuttleTimetableRepository, ShuttleMessagesService],
+  providers: [ShuttlesService, ShuttleTimetableRepository, ShuttleMessageFactory],
 })
 export class ShuttlesModule {}

--- a/services/api/app/src/api/public/shuttles/shuttles.service.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.service.ts
@@ -9,7 +9,12 @@ export class ShuttlesService {
 
   public async getRoutes(): Promise<ShuttleRouteListResult> {
     const routes = await this.shuttleTimetableRepository.findAll();
-    return { routes };
+    return {
+      routes: routes.map(route => ({
+        routeName: route.routeName,
+        updatedAt: route.updatedAt,
+      })),
+    };
   }
 
   public async getTimetable(routeName: string): Promise<ShuttleTimetableResult> {
@@ -19,6 +24,10 @@ export class ShuttlesService {
       throw new NotFoundException(`'${routeName}' 노선의 시간표를 찾을 수 없습니다.`);
     }
 
-    return { timetable: record };
+    return {
+      routeName: record.routeName,
+      timetable: record.timetable as Record<string, string[]>,
+      updatedAt: record.updatedAt,
+    };
   }
 }

--- a/services/api/app/src/api/public/users/dtos/results/user-profile-result.dto.ts
+++ b/services/api/app/src/api/public/users/dtos/results/user-profile-result.dto.ts
@@ -1,0 +1,5 @@
+export interface UserProfileResult {
+  userId: string;
+  campusName: string;
+  affiliationName: string;
+}

--- a/services/api/app/src/api/public/users/user-message.factory.ts
+++ b/services/api/app/src/api/public/users/user-message.factory.ts
@@ -4,22 +4,11 @@ import { Button } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createTextCard } from 'src/api/common/utils/component';
 import { BlockId } from 'src/api/common/utils/constants';
-import { User } from 'src/type-orm/entities/users/users.entity';
+import { UserProfileResult } from 'src/api/public/users/dtos/results/user-profile-result.dto';
 
 @Injectable()
-export class UserMessageService {
-  createProfileMessage(user: User): SkillTemplate {
-    const campus = user.campus?.name || '미등록';
-    const college = user.department?.college?.name;
-    const department = user.department?.name;
-
-    let affiliation = '';
-    if (!college && !department) {
-      affiliation = '미등록';
-    } else {
-      affiliation = college + ' ' + department;
-    }
-
+export class UserMessageFactory {
+  createProfileMessage(result: UserProfileResult): SkillTemplate {
     const buttons: Array<Button> = [
       {
         label: '캠퍼스 및 학과 변경',
@@ -30,7 +19,7 @@ export class UserMessageService {
 
     const textCard: TextCard = createTextCard(
       '내 정보',
-      `[ID]\n${user.id}\n\n[캠퍼스]\n${campus}\n\n[전공]\n${affiliation}`,
+      `[ID]\n${result.userId}\n\n[캠퍼스]\n${result.campusName}\n\n[전공]\n${result.affiliationName}`,
       buttons,
     );
 

--- a/services/api/app/src/api/public/users/users.controller.ts
+++ b/services/api/app/src/api/public/users/users.controller.ts
@@ -8,11 +8,11 @@ import { BlockId } from 'src/api/common/utils/constants';
 import { CampusesService } from 'src/api/public/campuses/campuses.service';
 import { CollegesService } from 'src/api/public/colleges/colleges.service';
 import { DepartmentsService } from 'src/api/public/departments/departments.service';
-import { CampusMessagesService } from 'src/api/public/campuses/campus-messages.service';
-import { CollegeMessagesService } from 'src/api/public/colleges/college-messages.service';
-import { CommonMessagesService } from 'src/api/public/common/common-messages.service';
-import { DepartmentMessagesService } from 'src/api/public/departments/department-messages.service';
-import { UserMessageService } from 'src/api/public/users/user-messages.service';
+import { CampusMessageFactory } from 'src/api/public/campuses/campus-message.factory';
+import { CollegeMessageFactory } from 'src/api/public/colleges/college-message.factory';
+import { CommonMessageFactory } from 'src/api/public/common/common-message.factory';
+import { DepartmentMessageFactory } from 'src/api/public/departments/department-message.factory';
+import { UserMessageFactory } from 'src/api/public/users/user-message.factory';
 import { User } from '../../../type-orm/entities/users/users.entity';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { FetchCurrentUser } from './decorators/fetch-current-user.decorator';
@@ -32,27 +32,25 @@ export class UsersController {
     private readonly campusesService: CampusesService,
     private readonly collegesService: CollegesService,
     private readonly departmentsService: DepartmentsService,
-    private readonly campusMessagesService: CampusMessagesService,
-    private readonly collegeMessagesService: CollegeMessagesService,
-    private readonly departmentMessagesService: DepartmentMessagesService,
-    private readonly userMessageService: UserMessageService,
-    private readonly commonMessagesService: CommonMessagesService,
+    private readonly campusMessageFactory: CampusMessageFactory,
+    private readonly collegeMessageFactory: CollegeMessageFactory,
+    private readonly departmentMessageFactory: DepartmentMessageFactory,
+    private readonly userMessageFactory: UserMessageFactory,
+    private readonly commonMessageFactory: CommonMessageFactory,
   ) {}
 
   @Post('profile/get')
   @FetchCurrentUser()
   getProfile(@CurrentUser() user: User): ResponseDTO {
-    const template = this.userMessageService.createProfileMessage(user);
+    const result = this.usersService.createProfileResult(user);
+    const template = this.userMessageFactory.createProfileMessage(result);
     return new ResponseDTO(template);
   }
 
   @Post('campuses/list')
   async listCampuses(): Promise<ResponseDTO> {
     const result = await this.campusesService.findAll();
-    const template = this.campusMessagesService.createCampusListCard(
-      result.campuses,
-      BlockId.COLLEGE_LIST,
-    );
+    const template = this.campusMessageFactory.createCampusListCard(result, BlockId.COLLEGE_LIST);
     return new ResponseDTO(template);
   }
 
@@ -62,9 +60,8 @@ export class UsersController {
     @ClientExtra(ListCollegesRequestDto) extra: ListCollegesRequestDto,
   ): Promise<ResponseDTO> {
     const result = await this.collegesService.findAll(extra.page ?? 1);
-    const template = this.collegeMessagesService.collegesListCard(
-      result.colleges,
-      result.total,
+    const template = this.collegeMessageFactory.createCollegeListCard(
+      result,
       extra.campusId,
       extra.page ?? 1,
       BlockId.DEPARTMENT_LIST,
@@ -78,9 +75,8 @@ export class UsersController {
     @ClientExtra(ListDepartmentsRequestDto) extra: ListDepartmentsRequestDto,
   ): Promise<ResponseDTO> {
     const result = await this.departmentsService.findAll(extra.collegeId, extra.page);
-    const template = await this.departmentMessagesService.departmentsListCard(
-      result.departments,
-      result.total,
+    const template = this.departmentMessageFactory.createDepartmentListCard(
+      result,
       extra,
       BlockId.UPDATE_DEPARTMENT,
     );
@@ -95,7 +91,7 @@ export class UsersController {
     @ClientExtra(UpsertDepartmentRequestDto) extra: UpsertDepartmentRequestDto,
   ): Promise<ResponseDTO> {
     await this.usersService.upsert(user.id, extra.campusId, extra.departmentId);
-    const template = this.commonMessagesService.createSimpleText('학과 정보를 등록했어!');
+    const template = this.commonMessageFactory.createSimpleText('학과 정보를 등록했어!');
     return new ResponseDTO(template);
   }
 }

--- a/services/api/app/src/api/public/users/users.module.ts
+++ b/services/api/app/src/api/public/users/users.module.ts
@@ -10,11 +10,11 @@ import { User } from '../../../type-orm/entities/users/users.entity';
 import { UsersRepository } from '../../../type-orm/entities/users/users.repository';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { UserMessageService } from 'src/api/public/users/user-messages.service';
-import { CommonMessagesService } from 'src/api/public/common/common-messages.service';
-import { CampusMessagesService } from 'src/api/public/campuses/campus-messages.service';
-import { CollegeMessagesService } from 'src/api/public/colleges/college-messages.service';
-import { DepartmentMessagesService } from 'src/api/public/departments/department-messages.service';
+import { UserMessageFactory } from 'src/api/public/users/user-message.factory';
+import { CommonMessageFactory } from 'src/api/public/common/common-message.factory';
+import { CampusMessageFactory } from 'src/api/public/campuses/campus-message.factory';
+import { CollegeMessageFactory } from 'src/api/public/colleges/college-message.factory';
+import { DepartmentMessageFactory } from 'src/api/public/departments/department-message.factory';
 
 @Module({
   imports: [
@@ -32,11 +32,11 @@ import { DepartmentMessagesService } from 'src/api/public/departments/department
       provide: APP_INTERCEPTOR,
       useClass: CurrentUserInterceptor,
     },
-    UserMessageService,
-    CommonMessagesService,
-    CampusMessagesService,
-    CollegeMessagesService,
-    DepartmentMessagesService,
+    UserMessageFactory,
+    CommonMessageFactory,
+    CampusMessageFactory,
+    CollegeMessageFactory,
+    DepartmentMessageFactory,
   ],
 })
 export class UsersModule {}

--- a/services/api/app/src/api/public/users/users.service.ts
+++ b/services/api/app/src/api/public/users/users.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { UpsertDepartmentResult } from 'src/api/public/users/dtos/results/upsert-department-result.dto';
+import { UserProfileResult } from 'src/api/public/users/dtos/results/user-profile-result.dto';
 import { Transactional } from 'typeorm-transactional';
 import { User } from '../../../type-orm/entities/users/users.entity';
 import { UsersRepository } from '../../../type-orm/entities/users/users.repository';
@@ -10,6 +11,21 @@ export class UsersService {
 
   public findOne(userId: string): Promise<User> {
     return this.usersRepository.findOne(userId);
+  }
+
+  public createProfileResult(user: User): UserProfileResult {
+    const campusName = user.campus?.name || '미등록';
+    const collegeName = user.department?.college?.name;
+    const departmentName = user.department?.name;
+
+    return {
+      userId: user.id,
+      campusName,
+      affiliationName:
+        !collegeName && !departmentName
+          ? '미등록'
+          : [collegeName, departmentName].filter(Boolean).join(' '),
+    };
   }
 
   @Transactional()


### PR DESCRIPTION
## 📌 개요

- 챗봇 응답 템플릿 생성 책임을 `MessageService`에서 `MessageFactory`로 분리했습니다.
- Service는 Entity/Repository 기반 비즈니스 결과를 만들고, Factory는 Result DTO를 Kakao response template로 변환하도록 경계를 정리했습니다.

## ✨ 작업 내용

- public 챗봇 응답 생성 클래스를 `*MessageFactory`로 변경하고 controller/module 주입명을 정리했습니다.
- 캠퍼스, 단과대학, 학과, 식당, 공지, 학사일정, 셔틀, 사용자 프로필 Result DTO가 TypeORM Entity를 직접 노출하지 않도록 plain object 구조로 변경했습니다.
- 공지 Result는 `Map<NoticeCategory, Notice[]>` 대신 카테고리 배열 기반 View DTO로 정리했습니다.
- native controller는 기존 앱용 JSON 응답 형태를 유지하면서 변경된 Result 구조를 사용하도록 수정했습니다.
- 관련 서비스/팩토리 테스트를 새 Result 구조 기준으로 갱신했습니다.

## 🔥 변경 이유

- 기존 `MessageService`는 DB 조회나 상태 변경보다 응답 템플릿 조립 역할에 가까워 Service 계층 책임과 이름이 맞지 않았습니다.
- Factory가 Entity를 직접 받으면 TypeORM relation 로딩 방식과 표현 계층이 강하게 결합되므로, Service Result를 기준으로 챗봇 응답을 생성하도록 분리했습니다.
- 모바일 앱/native API와 챗봇 API가 같은 Service 결과를 공유하되 각 controller가 필요한 응답 형태로 안전하게 변환할 수 있게 했습니다.

## 🧪 테스트

- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- `pnpm test -- notice-message.factory.spec.ts`
- `pnpm build`
- `pnpm test`
- `pnpm lint:check`

## 🔗 관련 이슈

- close #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 내부 메시지 빌딩 아키텍처를 개선하여 코드 유지보수성을 강화했습니다.
  * 데이터베이스 엔티티 의존성을 제거하고 명확한 데이터 구조로 전환했습니다.
  * 식당, 캠퍼스, 단과대, 학과, 공지사항, 학사일정, 셔틀, 사용자 프로필 등 전반적인 API 응답 구조를 표준화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->