### PR TITLE
[Refactor] 셔틀 시간표 계산 책임 분리

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm test

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,17 @@
+const path = require('node:path');
+
+const quote = value => JSON.stringify(value);
+
+const relativeFiles = (projectDir, files) =>
+  files.map(file => quote(path.relative(path.join(__dirname, projectDir), file))).join(' ');
+
+const projectCommands = (projectDir, files) => {
+  const args = relativeFiles(projectDir, files);
+
+  return [`pnpm --dir ${projectDir} exec eslint --fix ${args}`];
+};
+
+module.exports = {
+  'services/api/app/**/*.{js,ts}': files => projectCommands('services/api/app', files),
+  'mobile/**/*.{js,jsx,ts,tsx}': files => projectCommands('mobile', files),
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "server-node",
+  "private": true,
+  "packageManager": "pnpm@9.9.0",
+  "scripts": {
+    "prepare": "husky",
+    "lint-staged": "lint-staged",
+    "test": "pnpm run test:api && pnpm run test:mobile",
+    "test:api": "pnpm --dir services/api/app test -- --runInBand",
+    "test:mobile": "pnpm --dir mobile test -- --runInBand"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,258 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
+
+packages:
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
+
+  colorette@2.0.20: {}
+
+  commander@14.0.3: {}
+
+  emoji-regex@10.6.0: {}
+
+  environment@1.1.0: {}
+
+  eventemitter3@5.0.4: {}
+
+  get-east-asian-width@1.5.0: {}
+
+  husky@9.1.7: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.2
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  mimic-function@5.0.1: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  picomatch@4.0.4: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
+
+  signal-exit@4.1.0: {}
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  string-argv@0.3.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  tinyexec@1.1.2: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  yaml@2.8.3: {}

--- a/services/api/app/src/api/common/utils/date-format.ts
+++ b/services/api/app/src/api/common/utils/date-format.ts
@@ -1,0 +1,7 @@
+/** 로컬 달력 기준으로 `YYYY.MM.DD` 문자열을 반환합니다. */
+export function formatLocalDateDotSeparated(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}.${m}.${d}`;
+}

--- a/services/api/app/src/api/public/shuttles/dtos/results/shuttle-timetable-result.dto.ts
+++ b/services/api/app/src/api/public/shuttles/dtos/results/shuttle-timetable-result.dto.ts
@@ -1,5 +1,26 @@
 export type ShuttleTimetableSectionsResult = Record<string, string[]>;
 
+export interface ShuttleTimeEntryViewResult {
+  time: string;
+  memo: string | null;
+  status: 'past' | 'next' | 'future';
+}
+
+export interface ShuttleTimetableSectionViewResult {
+  label: string;
+  times: ShuttleTimeEntryViewResult[];
+}
+
+export interface ShuttleNextBusResult {
+  time: string;
+  minutesUntil: number;
+}
+
+export interface ShuttleTimetableViewResult {
+  nextBus: ShuttleNextBusResult | null;
+  sections: ShuttleTimetableSectionViewResult[];
+}
+
 export interface ShuttleTimetableResult {
   routeName: string;
   timetable: ShuttleTimetableSectionsResult;

--- a/services/api/app/src/api/public/shuttles/shuttle-timetable.calculator.spec.ts
+++ b/services/api/app/src/api/public/shuttles/shuttle-timetable.calculator.spec.ts
@@ -1,0 +1,60 @@
+import { ShuttleTimetableCalculator } from './shuttle-timetable.calculator';
+
+describe('ShuttleTimetableCalculator', () => {
+  const calculator = new ShuttleTimetableCalculator();
+
+  it('현재 KST 기준 다음 버스와 시간 상태를 계산한다', () => {
+    const result = calculator.calculate(
+      {
+        오전: ['08:30', '09:00'],
+        오후: ['13:00(금요일 미운행)'],
+      },
+      new Date('2026-05-04T00:45:00.000Z'), // KST 09:45, Monday
+    );
+
+    expect(result.nextBus).toEqual({ time: '13:00', minutesUntil: 195 });
+    expect(result.sections).toEqual([
+      {
+        label: '오전',
+        times: [
+          { time: '08:30', memo: null, status: 'past' },
+          { time: '09:00', memo: null, status: 'past' },
+        ],
+      },
+      {
+        label: '오후',
+        times: [{ time: '13:00', memo: '금요일 미운행', status: 'next' }],
+      },
+    ]);
+  });
+
+  it('금요일에는 금요일 미운행 버스를 다음 버스 후보에서 제외한다', () => {
+    const result = calculator.calculate(
+      {
+        오전: ['09:00(금요일 미운행)', '09:30'],
+      },
+      new Date('2026-05-01T00:45:00.000Z'), // KST 09:45, Friday
+    );
+
+    expect(result.nextBus).toBeNull();
+    expect(result.sections[0].times).toEqual([
+      { time: '09:00', memo: '금요일 미운행', status: 'past' },
+      { time: '09:30', memo: null, status: 'past' },
+    ]);
+  });
+
+  it('남은 버스가 없으면 다음 버스를 null로 반환한다', () => {
+    const result = calculator.calculate(
+      {
+        오전: ['08:30', '09:00'],
+      },
+      new Date('2026-05-04T01:00:00.000Z'), // KST 10:00
+    );
+
+    expect(result.nextBus).toBeNull();
+    expect(result.sections[0].times).toEqual([
+      { time: '08:30', memo: null, status: 'past' },
+      { time: '09:00', memo: null, status: 'past' },
+    ]);
+  });
+});

--- a/services/api/app/src/api/public/shuttles/shuttle-timetable.calculator.ts
+++ b/services/api/app/src/api/public/shuttles/shuttle-timetable.calculator.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ShuttleTimetableSectionsResult,
+  ShuttleTimetableViewResult,
+} from './dtos/results/shuttle-timetable-result.dto';
+
+/** KST(UTC+9) 기준 자정부터의 분 수 */
+function getKstMinutes(now: Date): number {
+  return (now.getUTCHours() * 60 + now.getUTCMinutes() + 9 * 60) % (24 * 60);
+}
+
+/** KST 기준 오늘이 금요일인지 여부 */
+function isKstFriday(now: Date): boolean {
+  const kstDay = new Date(now.getTime() + 9 * 60 * 60 * 1000).getUTCDay();
+  return kstDay === 5;
+}
+
+/** "HH:mm" 또는 "HH:mm(메모)" 형태에서 분 수 추출 */
+function parseMinutes(raw: string): number {
+  const match = raw.match(/^(\d{1,2}):(\d{2})/);
+  if (!match) return NaN;
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+/** "HH:mm(메모)" 형태를 시간/메모로 분리 */
+function splitTimeMemo(raw: string): { time: string; memo: string | null } {
+  const match = raw.match(/^(\d{1,2}:\d{2})\((.+)\)$/);
+  if (match) return { time: match[1], memo: match[2] };
+  return { time: raw, memo: null };
+}
+
+@Injectable()
+export class ShuttleTimetableCalculator {
+  public calculate(
+    timetable: ShuttleTimetableSectionsResult,
+    now: Date = new Date(),
+  ): ShuttleTimetableViewResult {
+    const nowMinutes = getKstMinutes(now);
+    const friday = isKstFriday(now);
+    const nextRaw = this.findNextRaw(timetable, nowMinutes, friday);
+
+    return {
+      nextBus: nextRaw
+        ? { time: splitTimeMemo(nextRaw).time, minutesUntil: parseMinutes(nextRaw) - nowMinutes }
+        : null,
+      sections: Object.entries(timetable).map(([label, times]) => ({
+        label,
+        times: times.map(raw => {
+          const { time, memo } = splitTimeMemo(raw);
+          const minutes = parseMinutes(raw);
+          const isNext = raw === nextRaw;
+          let status: 'past' | 'next' | 'future';
+
+          if (isNext) {
+            status = 'next';
+          } else {
+            status = minutes < nowMinutes ? 'past' : 'future';
+          }
+
+          return { time, memo, status };
+        }),
+      })),
+    };
+  }
+
+  private findNextRaw(
+    timetable: ShuttleTimetableSectionsResult,
+    nowMinutes: number,
+    friday: boolean,
+  ): string | null {
+    for (const times of Object.values(timetable)) {
+      for (const raw of times) {
+        const { memo } = splitTimeMemo(raw);
+        if (friday && memo?.includes('금요일 미운행')) continue;
+        if (parseMinutes(raw) >= nowMinutes) return raw;
+      }
+    }
+
+    return null;
+  }
+}

--- a/services/api/app/src/api/public/shuttles/shuttles-native.controller.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles-native.controller.ts
@@ -1,55 +1,21 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { NativeResponseDto } from 'src/api/common/dtos/native-response.dto';
+import { formatLocalDateDotSeparated } from 'src/api/common/utils/date-format';
 import { JwtAuthGuard } from 'src/api/public/users/guards/jwt-auth.guard';
 import { ShuttleRouteResponseDto } from './dtos/responses/shuttle-route-response.dto';
-import {
-  NextBusDto,
-  ShuttleTimetableResponseDto,
-  TimeEntryDto,
-  TimetableSectionDto,
-} from './dtos/responses/shuttle-timetable-response.dto';
+import { ShuttleTimetableResponseDto } from './dtos/responses/shuttle-timetable-response.dto';
+import { ShuttleTimetableCalculator } from './shuttle-timetable.calculator';
 import { ShuttlesService } from './shuttles.service';
-
-/** KST(UTC+9) 기준 자정부터의 분 수 */
-function getKstMinutes(): number {
-  const now = new Date();
-  return (now.getUTCHours() * 60 + now.getUTCMinutes() + 9 * 60) % (24 * 60);
-}
-
-/** KST 기준 오늘이 금요일인지 여부 */
-function isKstFriday(): boolean {
-  const now = new Date();
-  const kstDay = new Date(now.getTime() + 9 * 60 * 60 * 1000).getUTCDay();
-  return kstDay === 5;
-}
-
-/** "HH:mm" 또는 "HH:mm(메모)" 형태에서 분 수 추출 */
-function parseMinutes(raw: string): number {
-  const match = raw.match(/^(\d{1,2}):(\d{2})/);
-  if (!match) return NaN;
-  return Number(match[1]) * 60 + Number(match[2]);
-}
-
-/** "HH:mm(메모)" 형태를 시간/메모로 분리 */
-function splitTimeMemo(raw: string): { time: string; memo: string | null } {
-  const match = raw.match(/^(\d{1,2}:\d{2})\((.+)\)$/);
-  if (match) return { time: match[1], memo: match[2] };
-  return { time: raw, memo: null };
-}
-
-function formatUpdatedAt(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}.${m}.${d}`;
-}
 
 @ApiTags('shuttles')
 @Controller('shuttles')
 @UseGuards(JwtAuthGuard)
 export class ShuttlesNativeController {
-  constructor(private readonly shuttlesService: ShuttlesService) {}
+  constructor(
+    private readonly shuttlesService: ShuttlesService,
+    private readonly shuttleTimetableCalculator: ShuttleTimetableCalculator,
+  ) {}
 
   @Get('routes')
   @ApiOkResponse({ type: NativeResponseDto<ShuttleRouteResponseDto[]> })
@@ -68,50 +34,13 @@ export class ShuttlesNativeController {
     @Param('routeName') routeName: string,
   ): Promise<NativeResponseDto<ShuttleTimetableResponseDto>> {
     const result = await this.shuttlesService.getTimetable(routeName);
-    const rawTimetable = result.timetable;
-
-    const nowMinutes = getKstMinutes();
-    const friday = isKstFriday();
-
-    // 다음 버스 탐색: 금요일 미운행 항목은 오늘 금요일이면 제외
-    let nextRaw: string | null = null;
-    for (const times of Object.values(rawTimetable)) {
-      for (const raw of times) {
-        const { memo } = splitTimeMemo(raw);
-        if (friday && memo?.includes('금요일 미운행')) continue;
-        if (parseMinutes(raw) >= nowMinutes) {
-          nextRaw = raw;
-          break;
-        }
-      }
-      if (nextRaw) break;
-    }
-
-    const nextBus: NextBusDto | null = nextRaw
-      ? { time: splitTimeMemo(nextRaw).time, minutesUntil: parseMinutes(nextRaw) - nowMinutes }
-      : null;
-
-    const sections: TimetableSectionDto[] = Object.entries(rawTimetable).map(([label, times]) => ({
-      label,
-      times: times.map((raw): TimeEntryDto => {
-        const { time, memo } = splitTimeMemo(raw);
-        const minutes = parseMinutes(raw);
-        const isNext = raw === nextRaw;
-        let status: 'past' | 'next' | 'future';
-        if (isNext) {
-          status = 'next';
-        } else {
-          status = minutes < nowMinutes ? 'past' : 'future';
-        }
-        return { time, memo, status };
-      }),
-    }));
+    const timetableView = this.shuttleTimetableCalculator.calculate(result.timetable);
 
     const data: ShuttleTimetableResponseDto = {
       routeName: result.routeName,
-      nextBus,
-      sections,
-      updatedAt: formatUpdatedAt(result.updatedAt),
+      nextBus: timetableView.nextBus,
+      sections: timetableView.sections,
+      updatedAt: formatLocalDateDotSeparated(result.updatedAt),
     };
 
     return new NativeResponseDto(data);

--- a/services/api/app/src/api/public/shuttles/shuttles.module.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.module.ts
@@ -4,6 +4,7 @@ import { DatabaseModule } from 'src/type-orm/database.module';
 import { ShuttleTimetable } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.entity';
 import { ShuttleTimetableRepository } from 'src/type-orm/entities/shuttle-timetables/shuttle-timetable.repository';
 import { ShuttleMessageFactory } from './shuttle-message.factory';
+import { ShuttleTimetableCalculator } from './shuttle-timetable.calculator';
 import { ShuttlesController } from './shuttles.controller';
 import { ShuttlesNativeController } from './shuttles-native.controller';
 import { ShuttlesService } from './shuttles.service';
@@ -11,6 +12,11 @@ import { ShuttlesService } from './shuttles.service';
 @Module({
   imports: [DatabaseModule, TypeOrmModule.forFeature([ShuttleTimetable])],
   controllers: [ShuttlesController, ShuttlesNativeController],
-  providers: [ShuttlesService, ShuttleTimetableRepository, ShuttleMessageFactory],
+  providers: [
+    ShuttlesService,
+    ShuttleTimetableRepository,
+    ShuttleMessageFactory,
+    ShuttleTimetableCalculator,
+  ],
 })
 export class ShuttlesModule {}


### PR DESCRIPTION
## 📌 개요

- Native 셔틀버스 시간표 응답에서 사용하던 다음 버스 계산 책임을 별도 계산기로 분리했습니다.
- 컨트롤러는 조회 결과를 앱용 JSON 응답으로 매핑하는 역할에 집중하고, 시간표 해석과 상태 계산은 독립적으로 테스트 가능한 구조로 옮겼습니다.

## ✨ 작업 내용

- 셔틀 시간표의 현재 KST 기준 다음 버스, 금요일 미운행 제외, `past | next | future` 상태 계산을 전담하는 계산 로직을 분리했습니다.
- Native 셔틀버스 컨트롤러에서 시간 파싱과 다음 버스 탐색 로직을 제거해 응답 조립 흐름을 단순화했습니다.
- 셔틀 시간표 계산 결과 타입을 추가해 API 응답으로 변환하기 전의 내부 표현을 명확히 했습니다.
- 로컬 날짜를 `YYYY.MM.DD`로 포맷하는 공통 유틸을 추가했습니다.
- Husky와 lint-staged 기반 Git hook 초기 설정을 추가했습니다.

## 🔥 변경 이유

- 셔틀 시간표 계산이 컨트롤러에 직접 들어가 있어 Native API와 카카오 API가 공통 비즈니스 로직을 재사용하기 어려웠습니다.
- 현재 시간, 금요일 미운행, 운행 종료 같은 경계 조건은 회귀 위험이 크기 때문에 컨트롤러 밖에서 단위 테스트로 보호할 필요가 있었습니다.
- 백로그의 Native controller 책임 분리와 셔틀 다음 버스 계산 테스트 요구사항을 반영했습니다.

## 🧪 테스트

- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] `pnpm test -- shuttle-timetable.calculator.spec.ts --runInBand`
- [x] `pnpm run build`

## 🔗 관련 이슈

- close #76


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 셔틀 시간표 계산 기능에 대한 테스트 스위트 추가
  
* **Chores**
  * 커밋 전 자동 코드 린팅 설정 추가
  * 푸시 전 자동 테스트 실행 설정 추가
  * 패키지 관리 및 개발 도구 의존성 업데이트

* **Refactor**
  * 셔틀 시간표 표시 로직 최적화 및 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->