### PR TITLE
[Refactor] TypeORM 저장소 조회 로직 정리

### DIFF
--- a/services/api/app/src/api/public/cafeterias/domain/entities/cafeteria-diet.entity.ts
+++ b/services/api/app/src/api/public/cafeterias/domain/entities/cafeteria-diet.entity.ts
@@ -6,6 +6,9 @@ export class CafeteriaDiet {
   @PrimaryGeneratedColumn({ name: 'diet_id' })
   id: number;
 
+  @Column({ name: 'cafeteria_id' })
+  cafeteriaId: number;
+
   @Column()
   date: Date;
 

--- a/services/api/app/src/api/public/cafeterias/domain/entities/cafeteria.entity.ts
+++ b/services/api/app/src/api/public/cafeterias/domain/entities/cafeteria.entity.ts
@@ -7,6 +7,9 @@ export class Cafeteria {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ name: 'campus_id' })
+  campusId: number;
+
   @Column({ name: 'cafeteria_name_ko' })
   name: string;
 

--- a/services/api/app/src/api/public/cafeterias/infrastructure/cafeterias.repository.ts
+++ b/services/api/app/src/api/public/cafeterias/infrastructure/cafeterias.repository.ts
@@ -14,7 +14,7 @@ export class CafeteriasRepository {
     private readonly cafeteriaDietRepository: Repository<CafeteriaDiet>,
   ) {}
 
-  findCafeteriasByCampusId(campusId = 1): Promise<Cafeteria[]> {
+  findCafeteriasByCampusId(campusId: number): Promise<Cafeteria[]> {
     return this.cafeteriaRepository.find({
       where: {
         campus: {
@@ -24,16 +24,21 @@ export class CafeteriasRepository {
       order: {
         name: 'ASC',
       },
-      relations: ['campus'],
+      relations: {
+        campus: true,
+      },
     });
   }
 
   findCafeteriaById(cafeteriaId: number): Promise<Cafeteria | null> {
-    return this.cafeteriaRepository
-      .createQueryBuilder('cafeteria')
-      .leftJoinAndSelect('cafeteria.campus', 'campus')
-      .where('cafeteria.id = :cafeteriaId', { cafeteriaId })
-      .getOne();
+    return this.cafeteriaRepository.findOne({
+      where: {
+        id: cafeteriaId,
+      },
+      relations: {
+        campus: true,
+      },
+    });
   }
 
   /**
@@ -47,12 +52,17 @@ export class CafeteriasRepository {
     date: Date,
     time: DietTime,
   ): Promise<CafeteriaDiet[]> {
-    return this.cafeteriaDietRepository
-      .createQueryBuilder('diet')
-      .select(['diet.dishCategory', 'diet.dishType', 'diet.dishName'])
-      .where('diet.date = :date', { date })
-      .andWhere('diet.cafeteria_id = :cafeteriaId', { cafeteriaId })
-      .andWhere('diet.time = :time', { time })
-      .getMany();
+    return this.cafeteriaDietRepository.find({
+      select: {
+        dishCategory: true,
+        dishType: true,
+        dishName: true,
+      },
+      where: {
+        date,
+        cafeteriaId,
+        time,
+      },
+    });
   }
 }

--- a/services/api/app/src/api/public/colleges/infrastructure/colleges.repository.ts
+++ b/services/api/app/src/api/public/colleges/infrastructure/colleges.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ListCardConfig } from 'src/api/common/utils/constants';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { College } from 'src/api/public/colleges/domain/entities/college.entity';
 
 @Injectable()
@@ -12,12 +12,17 @@ export class CollegesRepository {
   ) {}
 
   findAll(page: number): Promise<[College[], number]> {
-    return this.collegesRepository
-      .createQueryBuilder('college')
-      .where("college.name != '공통'")
-      .orderBy('college.name', 'ASC')
-      .take(ListCardConfig.LIMIT)
-      .skip(ListCardConfig.LIMIT * (page - 1))
-      .getManyAndCount();
+    const limit = ListCardConfig.LIMIT;
+
+    return this.collegesRepository.findAndCount({
+      where: {
+        name: Not('공통'),
+      },
+      order: {
+        name: 'ASC',
+      },
+      take: limit,
+      skip: limit * (page - 1),
+    });
   }
 }

--- a/services/api/app/src/api/public/departments/application/departments.service.ts
+++ b/services/api/app/src/api/public/departments/application/departments.service.ts
@@ -19,7 +19,13 @@ export class DepartmentsService {
     },
   })
   public async findAll(collegeId: number, page: number): Promise<DepartmentListResult> {
-    const [departments, total] = await this.departmentsRepository.findByCollegeId(collegeId, page);
+    const safePage = Math.max(page, 1);
+
+    const [departments, total] = await this.departmentsRepository.findByCollegeId(
+      collegeId,
+      safePage,
+    );
+
     return {
       departments: departments.map(department => ({
         id: department.id,

--- a/services/api/app/src/api/public/departments/domain/entities/department.entity.ts
+++ b/services/api/app/src/api/public/departments/domain/entities/department.entity.ts
@@ -7,6 +7,9 @@ export class Department {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ name: 'college_id' })
+  collegeId: number;
+
   @Column({ name: 'department_ko' })
   name: string;
 

--- a/services/api/app/src/api/public/departments/infrastructure/departments.repository.ts
+++ b/services/api/app/src/api/public/departments/infrastructure/departments.repository.ts
@@ -12,14 +12,17 @@ export class DepartmentsRepository {
   ) {}
 
   findByCollegeId(collegeId: number, page: number): Promise<[Department[], number]> {
-    return this.departmentsRepository
-      .createQueryBuilder('department')
-      .where('department.college_id = :collegeId', {
+    const limit = ListCardConfig.LIMIT;
+
+    return this.departmentsRepository.findAndCount({
+      where: {
         collegeId,
-      })
-      .orderBy('department.name', 'ASC')
-      .take(ListCardConfig.LIMIT)
-      .skip(ListCardConfig.LIMIT * (page - 1))
-      .getManyAndCount();
+      },
+      order: {
+        name: 'ASC',
+      },
+      take: limit,
+      skip: limit * (page - 1),
+    });
   }
 }

--- a/services/api/app/src/api/public/notices/infrastructure/notice-categories.repository.ts
+++ b/services/api/app/src/api/public/notices/infrastructure/notice-categories.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { NoticeCategory } from 'src/api/public/notices/domain/entities/notice-category.entity';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 @Injectable()
 export class NoticeCategoriesRepository {
@@ -54,11 +54,12 @@ export class NoticeCategoriesRepository {
     departmentId: number,
     categoryNames: string[],
   ): Promise<NoticeCategory[]> {
-    return this.noticeCategoryRepository
-      .createQueryBuilder('category')
-      .where('category.department_id = :departmentId', { departmentId })
-      .andWhere('category.category IN (:...categoryNames)', { categoryNames })
-      .getMany();
+    return this.noticeCategoryRepository.find({
+      where: {
+        departmentId,
+        category: In(categoryNames),
+      },
+    });
   }
 
   /**

--- a/services/api/app/src/api/public/users/application/users.service.spec.ts
+++ b/services/api/app/src/api/public/users/application/users.service.spec.ts
@@ -6,6 +6,8 @@ import { UsersRepository } from 'src/api/public/users/infrastructure/users.repos
 const makeUser = (overrides: Partial<User> = {}): User =>
   ({
     id: 'kakao-user-id',
+    campusId: 1,
+    departmentId: 10,
     campus: { id: 1, name: '가좌캠퍼스' } as any,
     department: {
       id: 10,
@@ -61,16 +63,22 @@ describe('UsersService', () => {
 
   describe('upsert', () => {
     it('userId와 campusId, departmentId로 사용자 학과 정보를 저장한다', async () => {
-      const user = makeUser();
+      const user = makeUser({ campusId: 2, departmentId: 20 });
       usersRepository.save.mockResolvedValue(user);
 
-      const result = await service.upsert('kakao-user-id', 1, 10);
+      const result = await service.upsert('kakao-user-id', 2, 20);
 
-      expect(usersRepository.save).toHaveBeenCalledWith('kakao-user-id', 1, 10);
+      expect(usersRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'kakao-user-id',
+          campusId: 2,
+          departmentId: 20,
+        }),
+      );
       expect(result).toEqual({
         userId: user.id,
-        campusId: user.campus.id,
-        departmentId: user.department.id,
+        campusId: user.campusId,
+        departmentId: user.departmentId,
       });
     });
   });

--- a/services/api/app/src/api/public/users/application/users.service.ts
+++ b/services/api/app/src/api/public/users/application/users.service.ts
@@ -8,7 +8,7 @@ import { UsersRepository } from 'src/api/public/users/infrastructure/users.repos
 export class UsersService {
   constructor(private readonly usersRepository: UsersRepository) {}
 
-  public findOne(userId: string): Promise<User> {
+  public findOne(userId: string): Promise<User | null> {
     return this.usersRepository.findOne(userId);
   }
 
@@ -32,11 +32,16 @@ export class UsersService {
     campusId: number,
     departmentId: number,
   ): Promise<UpsertDepartmentResult> {
-    const user = await this.usersRepository.save(userId, campusId, departmentId);
+    const user = new User();
+
+    user.updateProfile(userId, campusId, departmentId);
+
+    const userResult = await this.usersRepository.save(user);
+
     return {
-      userId: user.id,
-      campusId: user.campus.id,
-      departmentId: user.department.id,
+      userId: userResult.id,
+      campusId: userResult.campusId,
+      departmentId: userResult.departmentId,
     };
   }
 }

--- a/services/api/app/src/api/public/users/domain/entities/users.entity.ts
+++ b/services/api/app/src/api/public/users/domain/entities/users.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Campus } from 'src/api/public/campuses/domain/entities/campus.entity';
 import { Department } from 'src/api/public/departments/domain/entities/department.entity';
 
@@ -7,6 +7,12 @@ export class User {
   @PrimaryColumn()
   id: string;
 
+  @Column({ name: 'campus_id' })
+  campusId: number;
+
+  @Column({ name: 'department_id' })
+  departmentId: number;
+
   @ManyToOne(() => Campus, campus => campus.users)
   @JoinColumn({ name: 'campus_id' })
   campus: Campus;
@@ -14,4 +20,10 @@ export class User {
   @ManyToOne(() => Department, department => department.users)
   @JoinColumn({ name: 'department_id' })
   department: Department;
+
+  updateProfile(userId: string, campusId: number, departmentId: number) {
+    this.id = userId;
+    this.campusId = campusId;
+    this.departmentId = departmentId;
+  }
 }

--- a/services/api/app/src/api/public/users/infrastructure/users.repository.ts
+++ b/services/api/app/src/api/public/users/infrastructure/users.repository.ts
@@ -10,21 +10,21 @@ export class UsersRepository {
     private readonly usersRepository: Repository<User>,
   ) {}
 
-  save(userId: string, campusId: number, departmentId: number): Promise<User> {
-    return this.usersRepository.save({
-      id: userId,
-      campus: { id: campusId },
-      department: { id: departmentId },
-    });
+  save(user: Partial<User>): Promise<User> {
+    return this.usersRepository.save(user);
   }
 
-  findOne(userId: string): Promise<User> {
-    return this.usersRepository
-      .createQueryBuilder('user')
-      .leftJoinAndSelect('user.campus', 'campus')
-      .leftJoinAndSelect('user.department', 'department')
-      .leftJoinAndSelect('department.college', 'college')
-      .where('user.id = :userId', { userId })
-      .getOne();
+  findOne(userId: string): Promise<User | null> {
+    return this.usersRepository.findOne({
+      where: {
+        id: userId,
+      },
+      relations: {
+        campus: true,
+        department: {
+          college: true,
+        },
+      },
+    });
   }
 }


### PR DESCRIPTION
## 📌 개요

- TypeORM 저장소 조회/저장 로직을 정리하고 사용자 프로필 갱신 저장 흐름을 보완했습니다.

## ✨ 작업 내용

- 식당, 단과대학, 학과, 공지 카테고리 조회 로직을 TypeORM Repository 메서드 기반으로 정리했습니다.
- 연관 엔티티 조건으로만 사용하던 외래키 컬럼을 엔티티에 명시해 조회와 저장 시 값을 직접 다룰 수 있도록 했습니다.
- 사용자 학과 정보 갱신 시 신규 사용자도 저장될 수 있도록 upsert 흐름을 보완했습니다.
- 학과 목록 조회에서 잘못된 page 값이 들어와도 최소 1페이지 기준으로 처리하도록 보정했습니다.

## 🔥 변경 이유

- QueryBuilder로 작성된 단순 조회를 Repository API로 정리해 읽기 쉽고 일관된 저장소 구현으로 맞췄습니다.
- 사용자 프로필 갱신 과정에서 기존 사용자 조회 결과에 의존하면 신규 사용자 저장이 실패할 수 있어, 저장 대상 값을 명시적으로 구성하도록 개선했습니다.
- FK 값을 엔티티에서 직접 참조할 수 있게 해 필터링과 저장 결과 반환을 안정적으로 처리하기 위함입니다.

## 🧪 테스트

- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- `pnpm --dir services/api/app test users.service.spec.ts -- --runInBand`
- `pnpm --dir services/api/app lint:check`
- `pnpm --dir services/api/app test -- --runInBand`

## 🔗 관련 이슈

- 해당 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 데이터 조회 로직 표준화로 쿼리 성능 및 일관성 개선
  * 학생, 캠퍼스, 단과대 관련 저장소 메서드 최적화

* **Bug Fixes**
  * 페이지 번호 입력값 검증 강화
  * 사용자 조회 시 데이터 부재에 따른 null 처리 개선

* **Tests**
  * 사용자 테스트 케이스 필드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->