### PR TITLE
[Refactor] 카카오 표현 계층 의존성 분리

### DIFF
--- a/services/api/app/src/api/common/presentation/kakao.constants.ts
+++ b/services/api/app/src/api/common/presentation/kakao.constants.ts
@@ -1,4 +1,4 @@
-export const enum BlockId {
+export const enum KakaoBlockId {
   // COMMON
   COLLEGE_LIST = '66cf226fa14fe55e3fc92498',
   DEPARTMENT_LIST = '66d05728e5715f75b2552b2c',
@@ -21,6 +21,6 @@ export const enum BlockId {
   SHUTTLE_TIMETABLE = '69b2c0babb823869c1c7fae6',
 }
 
-export const enum ListCardConfig {
-  LIMIT = 5,
-}
+export const KAKAO_LIST_CARD_ITEM_LIMIT = 5;
+export const KAKAO_NOTICE_CAROUSEL_ITEM_LIMIT = 4;
+export const KAKAO_REQUEST_CAMPUS_SELECTION_ID = -1;

--- a/services/api/app/src/api/public/cafeterias/application/cafeterias.service.ts
+++ b/services/api/app/src/api/public/cafeterias/application/cafeterias.service.ts
@@ -1,13 +1,13 @@
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { CacheKey } from 'src/api/common/decorators/cache-key.decorator';
-import { DietTime } from 'src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto';
 import {
   CafeteriaDietItemResult,
   CafeteriaDietResult,
   CafeteriaMenuGroupResult,
 } from 'src/api/public/cafeterias/application/dtos/results/cafeteria-diet-result.dto';
 import { CafeteriaListResult } from 'src/api/public/cafeterias/application/dtos/results/cafeteria-list-result.dto';
+import { DietTime } from 'src/api/public/cafeterias/application/utils/time';
 import { CafeteriasRepository } from 'src/api/public/cafeterias/infrastructure/cafeterias.repository';
 
 @Injectable()

--- a/services/api/app/src/api/public/cafeterias/application/dtos/results/cafeteria-diet-result.dto.ts
+++ b/services/api/app/src/api/public/cafeterias/application/dtos/results/cafeteria-diet-result.dto.ts
@@ -1,4 +1,4 @@
-import { DietTime } from 'src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto';
+import { DietTime } from 'src/api/public/cafeterias/application/utils/time';
 import { CafeteriaItemResult } from 'src/api/public/cafeterias/application/dtos/results/cafeteria-list-result.dto';
 
 export interface CafeteriaDietItemResult {

--- a/services/api/app/src/api/public/cafeterias/application/utils/time.ts
+++ b/services/api/app/src/api/public/cafeterias/application/utils/time.ts
@@ -1,4 +1,5 @@
-import { DietDate } from 'src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto';
+export type RelativeDietDate = '오늘' | '내일';
+export type DietTime = '아침' | '점심' | '저녁';
 
 /** 한국은 연중 UTC+9 (DST 없음). Intl 없이 서울 벽시계 시·분을 쓸 때 사용 */
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
@@ -28,7 +29,7 @@ const getTomorrow = (): Date => {
  * - dietDate가 제공되면 해당 날짜 반환
  * - 제공되지 않으면 서울 시간 기준 19시 전후로 오늘/내일 결정
  */
-export const getTodayOrTomorrow = (dietDate?: DietDate): Date => {
+export const getTodayOrTomorrow = (dietDate?: RelativeDietDate): Date => {
   if (dietDate) {
     return dietDate === '오늘' ? new Date() : getTomorrow();
   }
@@ -42,7 +43,7 @@ export const getTodayOrTomorrow = (dietDate?: DietDate): Date => {
  * - 서울 시간으로 변환 후 아침 시간 범위 내면 아침, 점심 시간 범위 내면 점심, 이후면 저녁
  * - 19:00 ~ 09:29: 아침, 09:30 ~ 13:29: 점심, 13:30 ~ 23:59: 저녁
  */
-export const getDietTime = (date: Date) => {
+export const getDietTime = (date: Date): DietTime => {
   const { hours, minutes } = getSeoulHoursMinutes(date);
   const totalMinutes = hours * 60 + minutes;
 

--- a/services/api/app/src/api/public/cafeterias/cafeterias.module.ts
+++ b/services/api/app/src/api/public/cafeterias/cafeterias.module.ts
@@ -7,12 +7,12 @@ import { Cafeteria } from 'src/api/public/cafeterias/domain/entities/cafeteria.e
 import { CampusesModule } from 'src/api/public/campuses/campuses.module';
 import { CampusMessageFactory } from 'src/api/public/campuses/presentation/campus-message.factory';
 import { CafeteriasNativeController } from 'src/api/public/cafeterias/presentation/cafeterias-native.controller';
-import { CafeteriasController } from 'src/api/public/cafeterias/presentation/cafeterias.controller';
+import { CafeteriasKakaoController } from 'src/api/public/cafeterias/presentation/cafeterias-kakao.controller';
 import { CafeteriasService } from 'src/api/public/cafeterias/application/cafeterias.service';
 
 @Module({
   imports: [CampusesModule, TypeOrmModule.forFeature([Cafeteria, CafeteriaDiet])],
-  controllers: [CafeteriasController, CafeteriasNativeController],
+  controllers: [CafeteriasKakaoController, CafeteriasNativeController],
   providers: [
     CafeteriasService,
     CafeteriasRepository,

--- a/services/api/app/src/api/public/cafeterias/infrastructure/cafeterias.repository.ts
+++ b/services/api/app/src/api/public/cafeterias/infrastructure/cafeterias.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DietTime } from 'src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto';
+import { DietTime } from 'src/api/public/cafeterias/application/utils/time';
 import { CafeteriaDiet } from 'src/api/public/cafeterias/domain/entities/cafeteria-diet.entity';
 import { Cafeteria } from 'src/api/public/cafeterias/domain/entities/cafeteria.entity';
 import { Repository } from 'typeorm';

--- a/services/api/app/src/api/public/cafeterias/presentation/cafeteria-message.factory.ts
+++ b/services/api/app/src/api/public/cafeterias/presentation/cafeteria-message.factory.ts
@@ -3,17 +3,20 @@ import { BasicCard, ListCard } from 'src/api/common/interfaces/response/fields/c
 import { Button, ListItem, QuickReply } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createBasicCard, createListCard } from 'src/api/common/utils/component';
-import { BlockId } from 'src/api/common/utils/constants';
 import {
-  DietDate,
+  KakaoBlockId,
+  KAKAO_REQUEST_CAMPUS_SELECTION_ID,
+} from 'src/api/common/presentation/kakao.constants';
+import {
   DietTime,
-} from 'src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto';
+  getDayWeek,
+  RelativeDietDate,
+} from 'src/api/public/cafeterias/application/utils/time';
 import { CafeteriaDietResult } from 'src/api/public/cafeterias/application/dtos/results/cafeteria-diet-result.dto';
 import {
   CafeteriaItemResult,
   CafeteriaListResult,
 } from 'src/api/public/cafeterias/application/dtos/results/cafeteria-list-result.dto';
-import { getDayWeek } from 'src/api/public/cafeterias/application/utils/time';
 
 @Injectable()
 export class CafeteriaMessageFactory {
@@ -27,7 +30,7 @@ export class CafeteriaMessageFactory {
       description: cafeteria.campus.name,
       imageUrl: cafeteria.thumbnailUrl,
       action: 'block',
-      blockId: BlockId.CAFETERIA_DIET_LIST,
+      blockId: KakaoBlockId.CAFETERIA_DIET_LIST,
       extra: {
         cafeteriaId: cafeteria.id,
       },
@@ -37,9 +40,9 @@ export class CafeteriaMessageFactory {
       {
         label: '더보기',
         action: 'block',
-        blockId: BlockId.CAFETERIA_LIST,
+        blockId: KakaoBlockId.CAFETERIA_LIST,
         extra: {
-          campusId: -1,
+          campusId: KAKAO_REQUEST_CAMPUS_SELECTION_ID,
         },
       },
     ];
@@ -96,14 +99,14 @@ export class CafeteriaMessageFactory {
   }
 
   private createDishDateQuickReplies(cafeteria: CafeteriaItemResult): QuickReply[] {
-    const dishDateTypes: DietDate[] = ['오늘', '내일'];
+    const dishDateTypes: RelativeDietDate[] = ['오늘', '내일'];
     const times: DietTime[] = ['아침', '점심', '저녁'];
 
     return dishDateTypes.flatMap(dishDateType =>
       times.map(time => ({
         label: `${dishDateType} ${time}`,
         action: 'block',
-        blockId: BlockId.CAFETERIA_DIET_LIST,
+        blockId: KakaoBlockId.CAFETERIA_DIET_LIST,
         extra: {
           cafeteriaId: cafeteria.id,
           date: dishDateType,

--- a/services/api/app/src/api/public/cafeterias/presentation/cafeterias-kakao.controller.ts
+++ b/services/api/app/src/api/public/cafeterias/presentation/cafeterias-kakao.controller.ts
@@ -11,7 +11,10 @@ import { CampusesService } from 'src/api/public/campuses/application/campuses.se
 import { CampusMessageFactory } from 'src/api/public/campuses/presentation/campus-message.factory';
 import { CurrentUser } from 'src/api/public/users/presentation/decorators/current-user.decorator';
 import { FetchCurrentUser } from 'src/api/public/users/presentation/decorators/fetch-current-user.decorator';
-import { BlockId } from 'src/api/common/utils/constants';
+import {
+  KakaoBlockId,
+  KAKAO_REQUEST_CAMPUS_SELECTION_ID,
+} from 'src/api/common/presentation/kakao.constants';
 import { User } from 'src/api/public/users/domain/entities/users.entity';
 import { KakaoAuthGuard } from 'src/api/public/users/presentation/guards/kakao-auth.guard';
 import { getDietTime, getTodayOrTomorrow } from 'src/api/public/cafeterias/application/utils/time';
@@ -21,7 +24,7 @@ import { CafeteriasService } from 'src/api/public/cafeterias/application/cafeter
 @Controller('cafeterias')
 @UseGuards(KakaoAuthGuard)
 @UseFilters(OpenBuilderExceptionFilter)
-export class CafeteriasController {
+export class CafeteriasKakaoController {
   constructor(
     private readonly cafeteriasService: CafeteriasService,
     private readonly cafeteriaMessageFactory: CafeteriaMessageFactory,
@@ -40,11 +43,14 @@ export class CafeteriasController {
     const userCampusId = user.campus?.id;
 
     // '더보기' 버튼 또는 캠퍼스 미설정 → 캠퍼스 선택 카드 반환
-    if (requestedCampusId === -1 || (!requestedCampusId && !userCampusId)) {
+    if (
+      requestedCampusId === KAKAO_REQUEST_CAMPUS_SELECTION_ID ||
+      (!requestedCampusId && !userCampusId)
+    ) {
       const result = await this.campusesService.findAll();
       const template = this.campusMessageFactory.createCampusListCard(
         result,
-        BlockId.CAFETERIA_LIST,
+        KakaoBlockId.CAFETERIA_LIST,
       );
       return new ResponseDTO(template);
     }

--- a/services/api/app/src/api/public/cafeterias/presentation/dtos/requests/get-cafeteria-diet-query.dto.ts
+++ b/services/api/app/src/api/public/cafeterias/presentation/dtos/requests/get-cafeteria-diet-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDefined, IsIn, IsISO8601 } from 'class-validator';
-import { DietTime } from './list-cafeteria-diet-request.dto';
+import { DietTime } from 'src/api/public/cafeterias/application/utils/time';
 
 export class GetCafeteriaDietQueryDto {
   @IsDefined({ message: 'date는 필수입니다.' })

--- a/services/api/app/src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto.ts
+++ b/services/api/app/src/api/public/cafeterias/presentation/dtos/requests/list-cafeteria-diet-request.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ClientExtraDto } from 'src/api/common/dtos/requests';
+import { DietTime, RelativeDietDate } from 'src/api/public/cafeterias/application/utils/time';
 
-export type DietDate = '오늘' | '내일';
-export type DietTime = '아침' | '점심' | '저녁';
+export type DietDate = RelativeDietDate;
 
 export class ListCafeteriaDietExtraRequestDto extends ClientExtraDto {
   @ApiProperty({ description: '식당 ID', example: 1 })

--- a/services/api/app/src/api/public/colleges/application/colleges.service.spec.ts
+++ b/services/api/app/src/api/public/colleges/application/colleges.service.spec.ts
@@ -1,0 +1,78 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Test, TestingModule } from '@nestjs/testing';
+import { College } from 'src/api/public/colleges/domain/entities/college.entity';
+import { CollegesRepository } from 'src/api/public/colleges/infrastructure/colleges.repository';
+import { CollegesService } from 'src/api/public/colleges/application/colleges.service';
+
+const makeCollege = (overrides: Partial<College> = {}): College =>
+  ({
+    id: 1,
+    name: '공과대학',
+    thumbnailUrl: 'https://example.com/college.jpg',
+    ...overrides,
+  } as College);
+
+describe('CollegesService', () => {
+  let service: CollegesService;
+  let collegesRepository: jest.Mocked<CollegesRepository>;
+  let cacheManager: { get: jest.Mock; set: jest.Mock };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CollegesService,
+        {
+          provide: CollegesRepository,
+          useValue: {
+            findAll: jest.fn(),
+          },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: jest.fn().mockResolvedValue(null),
+            set: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CollegesService>(CollegesService);
+    collegesRepository = module.get(CollegesRepository);
+    cacheManager = module.get(CACHE_MANAGER);
+  });
+
+  it('page와 pageSize로 단과대학 목록을 조회한다', async () => {
+    collegesRepository.findAll.mockResolvedValue([[makeCollege()], 1]);
+
+    const result = await service.findAll(2, 10);
+
+    expect(collegesRepository.findAll).toHaveBeenCalledWith(2, 10);
+    expect(result).toEqual({
+      colleges: [
+        {
+          id: 1,
+          name: '공과대학',
+          thumbnailUrl: 'https://example.com/college.jpg',
+        },
+      ],
+      total: 1,
+    });
+  });
+
+  it('page가 1보다 작으면 1로 보정한다', async () => {
+    collegesRepository.findAll.mockResolvedValue([[], 0]);
+
+    await service.findAll(0, 10);
+
+    expect(collegesRepository.findAll).toHaveBeenCalledWith(1, 10);
+  });
+
+  it('cache miss이면 pageSize를 포함한 캐시 키로 저장한다', async () => {
+    collegesRepository.findAll.mockResolvedValue([[], 0]);
+
+    const result = await service.findAll(0, 10);
+
+    expect(cacheManager.set).toHaveBeenCalledWith('colleges:page:1:size:10', result);
+  });
+});

--- a/services/api/app/src/api/public/colleges/application/colleges.service.ts
+++ b/services/api/app/src/api/public/colleges/application/colleges.service.ts
@@ -14,10 +14,12 @@ export class CollegesService {
   ) {}
 
   @CacheKey({
-    key: ([page]) => `colleges:page:${page as number}`,
+    key: ([page, pageSize]) =>
+      `colleges:page:${Math.max(page as number, 1)}:size:${pageSize as number}`,
   })
-  public async findAll(page: number): Promise<CollegeListResult> {
-    const [colleges, total] = await this.collegesRepository.findAll(page);
+  public async findAll(page: number, pageSize: number): Promise<CollegeListResult> {
+    const safePage = Math.max(page, 1);
+    const [colleges, total] = await this.collegesRepository.findAll(safePage, pageSize);
     return {
       colleges: colleges.map(college => ({
         id: college.id,

--- a/services/api/app/src/api/public/colleges/infrastructure/colleges.repository.ts
+++ b/services/api/app/src/api/public/colleges/infrastructure/colleges.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ListCardConfig } from 'src/api/common/utils/constants';
 import { Not, Repository } from 'typeorm';
 import { College } from 'src/api/public/colleges/domain/entities/college.entity';
 
@@ -11,9 +10,7 @@ export class CollegesRepository {
     private readonly collegesRepository: Repository<College>,
   ) {}
 
-  findAll(page: number): Promise<[College[], number]> {
-    const limit = ListCardConfig.LIMIT;
-
+  findAll(page: number, limit: number): Promise<[College[], number]> {
     return this.collegesRepository.findAndCount({
       where: {
         name: Not('공통'),

--- a/services/api/app/src/api/public/colleges/presentation/college-message.factory.ts
+++ b/services/api/app/src/api/public/colleges/presentation/college-message.factory.ts
@@ -3,7 +3,10 @@ import { ListCard } from 'src/api/common/interfaces/response/fields/component';
 import { ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard } from 'src/api/common/utils/component';
-import { BlockId, ListCardConfig } from 'src/api/common/utils/constants';
+import {
+  KakaoBlockId,
+  KAKAO_LIST_CARD_ITEM_LIMIT,
+} from 'src/api/common/presentation/kakao.constants';
 import { CollegeListResult } from 'src/api/public/colleges/application/dtos/results/college-list-result.dto';
 
 @Injectable()
@@ -33,14 +36,14 @@ export class CollegeMessageFactory {
 
     const collegeListCard: ListCard = createListCard(header, items);
 
-    const totalPages = Math.ceil(result.total / ListCardConfig.LIMIT);
+    const totalPages = Math.ceil(result.total / KAKAO_LIST_CARD_ITEM_LIMIT);
     const paginationButtons = [];
 
     if (page > 1) {
       paginationButtons.push({
         label: '이전',
         action: 'block',
-        blockId: BlockId.COLLEGE_LIST,
+        blockId: KakaoBlockId.COLLEGE_LIST,
         extra: {
           campusId: campusId,
           page: page - 1,
@@ -52,7 +55,7 @@ export class CollegeMessageFactory {
       paginationButtons.push({
         label: '다음',
         action: 'block',
-        blockId: BlockId.COLLEGE_LIST,
+        blockId: KakaoBlockId.COLLEGE_LIST,
         extra: {
           campusId: campusId,
           page: page + 1,

--- a/services/api/app/src/api/public/common/presentation/common-message.factory.ts
+++ b/services/api/app/src/api/public/common/presentation/common-message.factory.ts
@@ -3,7 +3,7 @@ import { TextCard } from 'src/api/common/interfaces/response/fields/component';
 import { Button } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createSimpleText, createTextCard } from 'src/api/common/utils/component';
-import { BlockId } from 'src/api/common/utils/constants';
+import { KakaoBlockId } from 'src/api/common/presentation/kakao.constants';
 
 @Injectable()
 export class CommonMessageFactory {
@@ -22,7 +22,7 @@ export class CommonMessageFactory {
       {
         label: '학과 등록',
         action: 'block',
-        blockId: BlockId.CHANGE_PROFILE,
+        blockId: KakaoBlockId.CHANGE_PROFILE,
       },
     ];
 

--- a/services/api/app/src/api/public/departments/application/departments.service.spec.ts
+++ b/services/api/app/src/api/public/departments/application/departments.service.spec.ts
@@ -1,0 +1,76 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Department } from 'src/api/public/departments/domain/entities/department.entity';
+import { DepartmentsRepository } from 'src/api/public/departments/infrastructure/departments.repository';
+import { DepartmentsService } from 'src/api/public/departments/application/departments.service';
+
+const makeDepartment = (overrides: Partial<Department> = {}): Department =>
+  ({
+    id: 1,
+    name: '컴퓨터공학부',
+    ...overrides,
+  } as Department);
+
+describe('DepartmentsService', () => {
+  let service: DepartmentsService;
+  let departmentsRepository: jest.Mocked<DepartmentsRepository>;
+  let cacheManager: { get: jest.Mock; set: jest.Mock };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DepartmentsService,
+        {
+          provide: DepartmentsRepository,
+          useValue: {
+            findByCollegeId: jest.fn(),
+          },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: jest.fn().mockResolvedValue(null),
+            set: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DepartmentsService>(DepartmentsService);
+    departmentsRepository = module.get(DepartmentsRepository);
+    cacheManager = module.get(CACHE_MANAGER);
+  });
+
+  it('collegeId, page, pageSize로 학과 목록을 조회한다', async () => {
+    departmentsRepository.findByCollegeId.mockResolvedValue([[makeDepartment()], 1]);
+
+    const result = await service.findAll(3, 2, 10);
+
+    expect(departmentsRepository.findByCollegeId).toHaveBeenCalledWith(3, 2, 10);
+    expect(result).toEqual({
+      departments: [
+        {
+          id: 1,
+          name: '컴퓨터공학부',
+        },
+      ],
+      total: 1,
+    });
+  });
+
+  it('page가 1보다 작으면 1로 보정한다', async () => {
+    departmentsRepository.findByCollegeId.mockResolvedValue([[], 0]);
+
+    await service.findAll(3, 0, 10);
+
+    expect(departmentsRepository.findByCollegeId).toHaveBeenCalledWith(3, 1, 10);
+  });
+
+  it('cache miss이면 pageSize를 포함한 캐시 키로 저장한다', async () => {
+    departmentsRepository.findByCollegeId.mockResolvedValue([[], 0]);
+
+    const result = await service.findAll(3, 0, 10);
+
+    expect(cacheManager.set).toHaveBeenCalledWith('departments:college:3:page:1:size:10', result);
+  });
+});

--- a/services/api/app/src/api/public/departments/application/departments.service.ts
+++ b/services/api/app/src/api/public/departments/application/departments.service.ts
@@ -14,16 +14,24 @@ export class DepartmentsService {
   ) {}
 
   @CacheKey({
-    key: ([collegeId, page]) => {
-      return `departments:college:${collegeId}:page:${page}`;
+    key: ([collegeId, page, pageSize]) => {
+      return `departments:college:${collegeId}:page:${Math.max(
+        page as number,
+        1,
+      )}:size:${pageSize}`;
     },
   })
-  public async findAll(collegeId: number, page: number): Promise<DepartmentListResult> {
+  public async findAll(
+    collegeId: number,
+    page: number,
+    pageSize: number,
+  ): Promise<DepartmentListResult> {
     const safePage = Math.max(page, 1);
 
     const [departments, total] = await this.departmentsRepository.findByCollegeId(
       collegeId,
       safePage,
+      pageSize,
     );
 
     return {

--- a/services/api/app/src/api/public/departments/infrastructure/departments.repository.ts
+++ b/services/api/app/src/api/public/departments/infrastructure/departments.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ListCardConfig } from 'src/api/common/utils/constants';
 import { Department } from 'src/api/public/departments/domain/entities/department.entity';
 import { Repository } from 'typeorm';
 
@@ -11,9 +10,7 @@ export class DepartmentsRepository {
     private readonly departmentsRepository: Repository<Department>,
   ) {}
 
-  findByCollegeId(collegeId: number, page: number): Promise<[Department[], number]> {
-    const limit = ListCardConfig.LIMIT;
-
+  findByCollegeId(collegeId: number, page: number, limit: number): Promise<[Department[], number]> {
     return this.departmentsRepository.findAndCount({
       where: {
         collegeId,

--- a/services/api/app/src/api/public/departments/presentation/department-message.factory.ts
+++ b/services/api/app/src/api/public/departments/presentation/department-message.factory.ts
@@ -3,7 +3,10 @@ import { ListCard } from 'src/api/common/interfaces/response/fields/component';
 import { ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard } from 'src/api/common/utils/component';
-import { BlockId, ListCardConfig } from 'src/api/common/utils/constants';
+import {
+  KakaoBlockId,
+  KAKAO_LIST_CARD_ITEM_LIMIT,
+} from 'src/api/common/presentation/kakao.constants';
 import { DepartmentListResult } from 'src/api/public/departments/application/dtos/results/department-list-result.dto';
 import { ListDepartmentsRequestDto } from 'src/api/public/users/presentation/dtos/requests/list-department-request.dto';
 
@@ -32,14 +35,14 @@ export class DepartmentMessageFactory {
 
     const departmentListCard: ListCard = createListCard(header, items);
 
-    const totalPages = Math.ceil(result.total / ListCardConfig.LIMIT);
+    const totalPages = Math.ceil(result.total / KAKAO_LIST_CARD_ITEM_LIMIT);
     const paginationButtons = [];
 
     if (extra.page > 1) {
       paginationButtons.push({
         label: '이전',
         action: 'block',
-        blockId: BlockId.DEPARTMENT_LIST,
+        blockId: KakaoBlockId.DEPARTMENT_LIST,
         extra: {
           campusId: extra.campusId,
           collegeId: extra.collegeId,
@@ -52,7 +55,7 @@ export class DepartmentMessageFactory {
       paginationButtons.push({
         label: '다음',
         action: 'block',
-        blockId: BlockId.DEPARTMENT_LIST,
+        blockId: KakaoBlockId.DEPARTMENT_LIST,
         extra: {
           campusId: extra.campusId,
           collegeId: extra.collegeId,

--- a/services/api/app/src/api/public/notices/application/notices.service.spec.ts
+++ b/services/api/app/src/api/public/notices/application/notices.service.spec.ts
@@ -165,6 +165,26 @@ describe('NoticesService', () => {
         expect.any(Array),
       );
     });
+
+    it('기본 limitPerCategory 10으로 공지사항을 조회한다', async () => {
+      const category = makeCategory({ id: 1, category: '학사' });
+      noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([category]);
+      noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
+
+      await service.getUniversityNotices();
+
+      expect(noticesRepository.findRecentByCategoryIds).toHaveBeenCalledWith([1], 10);
+    });
+
+    it('limitPerCategory 옵션으로 카테고리별 조회 개수를 변경한다', async () => {
+      const category = makeCategory({ id: 1, category: '학사' });
+      noticeCategoriesRepository.findByDepartmentIdAndCategories.mockResolvedValue([category]);
+      noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
+
+      await service.getUniversityNotices({ limitPerCategory: 10 });
+
+      expect(noticesRepository.findRecentByCategoryIds).toHaveBeenCalledWith([1], 10);
+    });
   });
 
   describe('getDepartmentNotices', () => {
@@ -241,6 +261,28 @@ describe('NoticesService', () => {
       await service.getDepartmentNotices(user);
 
       expect(noticeCategoriesRepository.findByDepartmentIds).toHaveBeenCalledWith([10]);
+    });
+
+    it('기본 limitPerCategory 10으로 학과 공지사항을 조회한다', async () => {
+      const user = makeUser();
+      const category = makeCategory({ id: 1 });
+      noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([category]);
+      noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
+
+      await service.getDepartmentNotices(user);
+
+      expect(noticesRepository.findRecentByCategoryIds).toHaveBeenCalledWith([1], 10);
+    });
+
+    it('limitPerCategory 옵션으로 학과 공지사항 조회 개수를 변경한다', async () => {
+      const user = makeUser();
+      const category = makeCategory({ id: 1 });
+      noticeCategoriesRepository.findByDepartmentIds.mockResolvedValue([category]);
+      noticesRepository.findRecentByCategoryIds.mockResolvedValue(new Map());
+
+      await service.getDepartmentNotices(user, { limitPerCategory: 10 });
+
+      expect(noticesRepository.findRecentByCategoryIds).toHaveBeenCalledWith([1], 10);
     });
   });
 });

--- a/services/api/app/src/api/public/notices/application/notices.service.ts
+++ b/services/api/app/src/api/public/notices/application/notices.service.ts
@@ -15,7 +15,7 @@ export class NoticesService {
 
   private readonly TARGET_CATEGORIES = ['기관', '채용', '장학', '외부기관 행사', '학사'];
 
-  private readonly CAROUSEL_ITEMS_LIMIT = 4;
+  private readonly DEFAULT_LIMIT_PER_CATEGORY = 10;
 
   constructor(
     private readonly noticesRepository: NoticesRepository,
@@ -26,7 +26,8 @@ export class NoticesService {
    * 학교 공지사항 조회
    * @returns 카테고리별 공지사항 Map (데이터가 없으면 빈 Map)
    */
-  async getUniversityNotices(): Promise<NoticeListResult> {
+  async getUniversityNotices(options?: { limitPerCategory?: number }): Promise<NoticeListResult> {
+    const limitPerCategory = options?.limitPerCategory ?? this.DEFAULT_LIMIT_PER_CATEGORY;
     const categories = await this.noticeCategoriesRepository.findByDepartmentIdAndCategories(
       this.UNIVERSITY_DEPARTMENT_ID,
       this.TARGET_CATEGORIES,
@@ -39,7 +40,7 @@ export class NoticesService {
     const categoryIds = categories.map(category => category.id);
     const noticesByCategory = await this.noticesRepository.findRecentByCategoryIds(
       categoryIds,
-      this.CAROUSEL_ITEMS_LIMIT,
+      limitPerCategory,
     );
 
     const categoriesResult: NoticeCategoryResult[] = [];
@@ -62,10 +63,14 @@ export class NoticesService {
    * @param user 현재 사용자 (department 미설정 시 빈 Map 반환)
    * @returns 카테고리별 공지사항 Map
    */
-  async getDepartmentNotices(user: User): Promise<NoticeListResult> {
+  async getDepartmentNotices(
+    user: User,
+    options?: { limitPerCategory?: number },
+  ): Promise<NoticeListResult> {
     if (!user.department) {
       return { categories: [] };
     }
+    const limitPerCategory = options?.limitPerCategory ?? this.DEFAULT_LIMIT_PER_CATEGORY;
 
     const departmentIds: number[] = [user.department.id];
     if (user.department.parentDepartmentId) {
@@ -81,7 +86,7 @@ export class NoticesService {
     const categoryIds = categories.map(category => category.id);
     const noticesByCategory = await this.noticesRepository.findRecentByCategoryIds(
       categoryIds,
-      this.CAROUSEL_ITEMS_LIMIT,
+      limitPerCategory,
     );
 
     const categoriesResult: NoticeCategoryResult[] = [];

--- a/services/api/app/src/api/public/notices/notices.module.ts
+++ b/services/api/app/src/api/public/notices/notices.module.ts
@@ -6,12 +6,12 @@ import { Notice } from 'src/api/public/notices/domain/entities/notice.entity';
 import { NoticeCategoriesRepository } from 'src/api/public/notices/infrastructure/notice-categories.repository';
 import { NoticeMessageFactory } from 'src/api/public/notices/presentation/notice-message.factory';
 import { NoticesRepository } from 'src/api/public/notices/infrastructure/notices.repository';
-import { NoticesController } from 'src/api/public/notices/presentation/notices.controller';
+import { NoticesKakaoController } from 'src/api/public/notices/presentation/notices-kakao.controller';
 import { NoticesService } from 'src/api/public/notices/application/notices.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Notice, NoticeCategory])],
-  controllers: [NoticesController],
+  controllers: [NoticesKakaoController],
   providers: [
     NoticesService,
     NoticesRepository,

--- a/services/api/app/src/api/public/notices/presentation/notices-kakao.controller.ts
+++ b/services/api/app/src/api/public/notices/presentation/notices-kakao.controller.ts
@@ -12,12 +12,13 @@ import { ListDepartmentNoticeRequestDto } from './dtos/requests/list-department-
 import { ListUniversityNoticeRequestDto } from './dtos/requests/list-university-notice-request.dto';
 import { KakaoAuthGuard } from 'src/api/public/users/presentation/guards/kakao-auth.guard';
 import { NoticesService } from 'src/api/public/notices/application/notices.service';
+import { KAKAO_NOTICE_CAROUSEL_ITEM_LIMIT } from 'src/api/common/presentation/kakao.constants';
 
 @ApiTags('notices')
 @Controller('notices')
 @UseGuards(KakaoAuthGuard)
 @UseFilters(OpenBuilderExceptionFilter)
-export class NoticesController {
+export class NoticesKakaoController {
   constructor(
     private readonly noticesService: NoticesService,
     private readonly noticeMessageFactory: NoticeMessageFactory,
@@ -27,7 +28,9 @@ export class NoticesController {
   @Post('university')
   @ApiSkillBody(ListUniversityNoticeRequestDto)
   async listUniversityNotices() {
-    const result = await this.noticesService.getUniversityNotices();
+    const result = await this.noticesService.getUniversityNotices({
+      limitPerCategory: KAKAO_NOTICE_CAROUSEL_ITEM_LIMIT,
+    });
 
     if (result.categories.length === 0) {
       const template = this.commonMessageFactory.createSimpleText('현재 등록된 공지사항이 없어!');
@@ -47,7 +50,9 @@ export class NoticesController {
       return new ResponseDTO(template);
     }
 
-    const result = await this.noticesService.getDepartmentNotices(user);
+    const result = await this.noticesService.getDepartmentNotices(user, {
+      limitPerCategory: KAKAO_NOTICE_CAROUSEL_ITEM_LIMIT,
+    });
 
     if (result.categories.length === 0) {
       const template = this.commonMessageFactory.createSimpleText('현재 등록된 공지사항이 없어!');

--- a/services/api/app/src/api/public/schedules/presentation/schedule-message.factory.ts
+++ b/services/api/app/src/api/public/schedules/presentation/schedule-message.factory.ts
@@ -3,7 +3,7 @@ import { TextCard } from 'src/api/common/interfaces/response/fields/component';
 import { Button, QuickReply } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createTextCard } from 'src/api/common/utils/component';
-import { BlockId } from 'src/api/common/utils/constants';
+import { KakaoBlockId } from 'src/api/common/presentation/kakao.constants';
 import { AcademicScheduleResult } from 'src/api/public/schedules/application/dtos/results/academic-schedule-result.dto';
 
 @Injectable()
@@ -75,7 +75,7 @@ export class ScheduleMessageFactory {
       replies.push({
         label: `${month}월`,
         action: 'block',
-        blockId: BlockId.ACADEMIC_SCHEDULE,
+        blockId: KakaoBlockId.ACADEMIC_SCHEDULE,
         extra: { month },
       });
     }

--- a/services/api/app/src/api/public/schedules/presentation/schedules-kakao.controller.ts
+++ b/services/api/app/src/api/public/schedules/presentation/schedules-kakao.controller.ts
@@ -14,7 +14,7 @@ import { SchedulesService } from 'src/api/public/schedules/application/schedules
 @Controller('schedules')
 @UseGuards(KakaoAuthGuard)
 @UseFilters(OpenBuilderExceptionFilter)
-export class SchedulesController {
+export class SchedulesKakaoController {
   constructor(
     private readonly schedulesService: SchedulesService,
     private readonly scheduleMessageFactory: ScheduleMessageFactory,

--- a/services/api/app/src/api/public/schedules/schedules.module.ts
+++ b/services/api/app/src/api/public/schedules/schedules.module.ts
@@ -4,12 +4,12 @@ import { CommonMessageFactory } from 'src/api/public/common/presentation/common-
 import { AcademicCalendarsRepository } from 'src/api/public/schedules/infrastructure/academic-calendars.repository';
 import { AcademicCalendar } from 'src/api/public/schedules/domain/entities/academic-calendar.entity';
 import { ScheduleMessageFactory } from 'src/api/public/schedules/presentation/schedule-message.factory';
-import { SchedulesController } from 'src/api/public/schedules/presentation/schedules.controller';
+import { SchedulesKakaoController } from 'src/api/public/schedules/presentation/schedules-kakao.controller';
 import { SchedulesService } from 'src/api/public/schedules/application/schedules.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AcademicCalendar])],
-  controllers: [SchedulesController],
+  controllers: [SchedulesKakaoController],
   providers: [
     SchedulesService,
     AcademicCalendarsRepository,

--- a/services/api/app/src/api/public/shuttles/presentation/shuttle-message.factory.ts
+++ b/services/api/app/src/api/public/shuttles/presentation/shuttle-message.factory.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Button, ListItem } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createListCard, createTextCard } from 'src/api/common/utils/component';
-import { BlockId } from 'src/api/common/utils/constants';
+import { KakaoBlockId } from 'src/api/common/presentation/kakao.constants';
 import { ShuttleRouteListResult } from 'src/api/public/shuttles/application/dtos/results/shuttle-route-list-result.dto';
 import { ShuttleTimetableResult } from 'src/api/public/shuttles/application/dtos/results/shuttle-timetable-result.dto';
 
@@ -22,7 +22,7 @@ export class ShuttleMessageFactory {
     const items: ListItem[] = result.routes.map(route => ({
       title: route.routeName,
       action: 'block',
-      blockId: BlockId.SHUTTLE_TIMETABLE,
+      blockId: KakaoBlockId.SHUTTLE_TIMETABLE,
       extra: { routeName: route.routeName },
     }));
 
@@ -49,7 +49,7 @@ export class ShuttleMessageFactory {
       {
         label: '뒤로 가기',
         action: 'block',
-        blockId: BlockId.SHUTTLE_ROUTES,
+        blockId: KakaoBlockId.SHUTTLE_ROUTES,
       },
       {
         label: '공식 홈페이지',

--- a/services/api/app/src/api/public/shuttles/presentation/shuttles-kakao.controller.ts
+++ b/services/api/app/src/api/public/shuttles/presentation/shuttles-kakao.controller.ts
@@ -13,7 +13,7 @@ import { ShuttlesService } from 'src/api/public/shuttles/application/shuttles.se
 @Controller('shuttles')
 @UseGuards(KakaoAuthGuard)
 @UseFilters(OpenBuilderExceptionFilter)
-export class ShuttlesController {
+export class ShuttlesKakaoController {
   constructor(
     private readonly shuttlesService: ShuttlesService,
     private readonly shuttleMessageFactory: ShuttleMessageFactory,

--- a/services/api/app/src/api/public/shuttles/shuttles.module.ts
+++ b/services/api/app/src/api/public/shuttles/shuttles.module.ts
@@ -4,13 +4,13 @@ import { ShuttleTimetable } from 'src/api/public/shuttles/domain/entities/shuttl
 import { ShuttleTimetableRepository } from 'src/api/public/shuttles/infrastructure/shuttle-timetable.repository';
 import { ShuttleMessageFactory } from 'src/api/public/shuttles/presentation/shuttle-message.factory';
 import { ShuttleTimetableCalculator } from 'src/api/public/shuttles/application/shuttle-timetable.calculator';
-import { ShuttlesController } from 'src/api/public/shuttles/presentation/shuttles.controller';
+import { ShuttlesKakaoController } from 'src/api/public/shuttles/presentation/shuttles-kakao.controller';
 import { ShuttlesNativeController } from 'src/api/public/shuttles/presentation/shuttles-native.controller';
 import { ShuttlesService } from 'src/api/public/shuttles/application/shuttles.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ShuttleTimetable])],
-  controllers: [ShuttlesController, ShuttlesNativeController],
+  controllers: [ShuttlesKakaoController, ShuttlesNativeController],
   providers: [
     ShuttlesService,
     ShuttleTimetableRepository,

--- a/services/api/app/src/api/public/users/application/dtos/results/user-profile-result.dto.ts
+++ b/services/api/app/src/api/public/users/application/dtos/results/user-profile-result.dto.ts
@@ -1,5 +1,21 @@
+export interface UserProfileCampusResult {
+  id: number;
+  name: string;
+}
+
+export interface UserProfileCollegeResult {
+  id: number;
+  name: string;
+}
+
+export interface UserProfileDepartmentResult {
+  id: number;
+  name: string;
+}
+
 export interface UserProfileResult {
   userId: string;
-  campusName: string;
-  affiliationName: string;
+  campus: UserProfileCampusResult | null;
+  college: UserProfileCollegeResult | null;
+  department: UserProfileDepartmentResult | null;
 }

--- a/services/api/app/src/api/public/users/application/users.service.spec.ts
+++ b/services/api/app/src/api/public/users/application/users.service.spec.ts
@@ -61,6 +61,43 @@ describe('UsersService', () => {
     });
   });
 
+  describe('createProfileResult', () => {
+    it('사용자 프로필을 구조화된 값으로 반환한다', () => {
+      const user = makeUser();
+
+      const result = service.createProfileResult(user);
+
+      expect(result).toEqual({
+        userId: 'kakao-user-id',
+        campus: {
+          id: 1,
+          name: '가좌캠퍼스',
+        },
+        college: {
+          id: 3,
+          name: '공과대학',
+        },
+        department: {
+          id: 10,
+          name: '컴퓨터공학부',
+        },
+      });
+    });
+
+    it('캠퍼스와 학과가 없으면 null로 반환한다', () => {
+      const user = makeUser({ campus: null, department: null });
+
+      const result = service.createProfileResult(user);
+
+      expect(result).toEqual({
+        userId: 'kakao-user-id',
+        campus: null,
+        college: null,
+        department: null,
+      });
+    });
+  });
+
   describe('upsert', () => {
     it('userId와 campusId, departmentId로 사용자 학과 정보를 저장한다', async () => {
       const user = makeUser({ campusId: 2, departmentId: 20 });

--- a/services/api/app/src/api/public/users/application/users.service.ts
+++ b/services/api/app/src/api/public/users/application/users.service.ts
@@ -13,17 +13,26 @@ export class UsersService {
   }
 
   public createProfileResult(user: User): UserProfileResult {
-    const campusName = user.campus?.name || '미등록';
-    const collegeName = user.department?.college?.name;
-    const departmentName = user.department?.name;
-
     return {
       userId: user.id,
-      campusName,
-      affiliationName:
-        !collegeName && !departmentName
-          ? '미등록'
-          : [collegeName, departmentName].filter(Boolean).join(' '),
+      campus: user.campus
+        ? {
+            id: user.campus.id,
+            name: user.campus.name,
+          }
+        : null,
+      college: user.department?.college
+        ? {
+            id: user.department.college.id,
+            name: user.department.college.name,
+          }
+        : null,
+      department: user.department
+        ? {
+            id: user.department.id,
+            name: user.department.name,
+          }
+        : null,
     };
   }
 

--- a/services/api/app/src/api/public/users/presentation/user-message.factory.spec.ts
+++ b/services/api/app/src/api/public/users/presentation/user-message.factory.spec.ts
@@ -1,0 +1,45 @@
+import { UserMessageFactory } from 'src/api/public/users/presentation/user-message.factory';
+
+describe('UserMessageFactory', () => {
+  let factory: UserMessageFactory;
+
+  beforeEach(() => {
+    factory = new UserMessageFactory();
+  });
+
+  it('구조화된 프로필을 기존 카카오 프로필 문구로 렌더링한다', () => {
+    const result = factory.createProfileMessage({
+      userId: 'kakao-user-id',
+      campus: { id: 1, name: '가좌캠퍼스' },
+      college: { id: 3, name: '공과대학' },
+      department: { id: 10, name: '컴퓨터공학부' },
+    });
+
+    expect(result.outputs[0]).toEqual(
+      expect.objectContaining({
+        textCard: expect.objectContaining({
+          title: '내 정보',
+          description:
+            '[ID]\nkakao-user-id\n\n[캠퍼스]\n가좌캠퍼스\n\n[전공]\n공과대학 컴퓨터공학부',
+        }),
+      }),
+    );
+  });
+
+  it('미설정 프로필을 기존 미등록 문구로 렌더링한다', () => {
+    const result = factory.createProfileMessage({
+      userId: 'kakao-user-id',
+      campus: null,
+      college: null,
+      department: null,
+    });
+
+    expect(result.outputs[0]).toEqual(
+      expect.objectContaining({
+        textCard: expect.objectContaining({
+          description: '[ID]\nkakao-user-id\n\n[캠퍼스]\n미등록\n\n[전공]\n미등록',
+        }),
+      }),
+    );
+  });
+});

--- a/services/api/app/src/api/public/users/presentation/user-message.factory.ts
+++ b/services/api/app/src/api/public/users/presentation/user-message.factory.ts
@@ -3,23 +3,28 @@ import { TextCard } from 'src/api/common/interfaces/response/fields/component';
 import { Button } from 'src/api/common/interfaces/response/fields/etc';
 import { SkillTemplate } from 'src/api/common/interfaces/response/fields/template';
 import { createTextCard } from 'src/api/common/utils/component';
-import { BlockId } from 'src/api/common/utils/constants';
+import { KakaoBlockId } from 'src/api/common/presentation/kakao.constants';
 import { UserProfileResult } from 'src/api/public/users/application/dtos/results/user-profile-result.dto';
 
 @Injectable()
 export class UserMessageFactory {
   createProfileMessage(result: UserProfileResult): SkillTemplate {
+    const campusName = result.campus?.name ?? '미등록';
+    const affiliationName =
+      !result.college && !result.department
+        ? '미등록'
+        : [result.college?.name, result.department?.name].filter(Boolean).join(' ');
     const buttons: Array<Button> = [
       {
         label: '캠퍼스 및 학과 변경',
         action: 'block',
-        blockId: BlockId.CHANGE_PROFILE,
+        blockId: KakaoBlockId.CHANGE_PROFILE,
       },
     ];
 
     const textCard: TextCard = createTextCard(
       '내 정보',
-      `[ID]\n${result.userId}\n\n[캠퍼스]\n${result.campusName}\n\n[전공]\n${result.affiliationName}`,
+      `[ID]\n${result.userId}\n\n[캠퍼스]\n${campusName}\n\n[전공]\n${affiliationName}`,
       buttons,
     );
 

--- a/services/api/app/src/api/public/users/presentation/users-kakao.controller.ts
+++ b/services/api/app/src/api/public/users/presentation/users-kakao.controller.ts
@@ -4,7 +4,10 @@ import { ApiSkillBody } from 'src/api/common/decorators/api-skill-body.decorator
 import { ClientExtra } from 'src/api/common/decorators/skill-extra.decorator';
 import { ResponseDTO } from 'src/api/common/dtos/response.dto';
 import { OpenBuilderExceptionFilter } from 'src/api/common/filters/open-builder-exception.filter';
-import { BlockId } from 'src/api/common/utils/constants';
+import {
+  KakaoBlockId,
+  KAKAO_LIST_CARD_ITEM_LIMIT,
+} from 'src/api/common/presentation/kakao.constants';
 import { CampusesService } from 'src/api/public/campuses/application/campuses.service';
 import { CollegesService } from 'src/api/public/colleges/application/colleges.service';
 import { DepartmentsService } from 'src/api/public/departments/application/departments.service';
@@ -26,7 +29,7 @@ import { UsersService } from 'src/api/public/users/application/users.service';
 @Controller('users')
 @UseGuards(KakaoAuthGuard)
 @UseFilters(OpenBuilderExceptionFilter)
-export class UsersController {
+export class UsersKakaoController {
   constructor(
     private readonly usersService: UsersService,
     private readonly campusesService: CampusesService,
@@ -50,7 +53,10 @@ export class UsersController {
   @Post('campuses/list')
   async listCampuses(): Promise<ResponseDTO> {
     const result = await this.campusesService.findAll();
-    const template = this.campusMessageFactory.createCampusListCard(result, BlockId.COLLEGE_LIST);
+    const template = this.campusMessageFactory.createCampusListCard(
+      result,
+      KakaoBlockId.COLLEGE_LIST,
+    );
     return new ResponseDTO(template);
   }
 
@@ -59,12 +65,12 @@ export class UsersController {
   async listColleges(
     @ClientExtra(ListCollegesRequestDto) extra: ListCollegesRequestDto,
   ): Promise<ResponseDTO> {
-    const result = await this.collegesService.findAll(extra.page ?? 1);
+    const result = await this.collegesService.findAll(extra.page ?? 1, KAKAO_LIST_CARD_ITEM_LIMIT);
     const template = this.collegeMessageFactory.createCollegeListCard(
       result,
       extra.campusId,
       extra.page ?? 1,
-      BlockId.DEPARTMENT_LIST,
+      KakaoBlockId.DEPARTMENT_LIST,
     );
     return new ResponseDTO(template);
   }
@@ -74,11 +80,15 @@ export class UsersController {
   async listDepartments(
     @ClientExtra(ListDepartmentsRequestDto) extra: ListDepartmentsRequestDto,
   ): Promise<ResponseDTO> {
-    const result = await this.departmentsService.findAll(extra.collegeId, extra.page);
+    const result = await this.departmentsService.findAll(
+      extra.collegeId,
+      extra.page ?? 1,
+      KAKAO_LIST_CARD_ITEM_LIMIT,
+    );
     const template = this.departmentMessageFactory.createDepartmentListCard(
       result,
       extra,
-      BlockId.UPDATE_DEPARTMENT,
+      KakaoBlockId.UPDATE_DEPARTMENT,
     );
     return new ResponseDTO(template);
   }

--- a/services/api/app/src/api/public/users/users.module.ts
+++ b/services/api/app/src/api/public/users/users.module.ts
@@ -7,7 +7,7 @@ import { DepartmentsModule } from 'src/api/public/departments/departments.module
 import { CurrentUserInterceptor } from 'src/api/public/users/presentation/interceptors/current-user.interceptor';
 import { User } from 'src/api/public/users/domain/entities/users.entity';
 import { UsersRepository } from 'src/api/public/users/infrastructure/users.repository';
-import { UsersController } from 'src/api/public/users/presentation/users.controller';
+import { UsersKakaoController } from 'src/api/public/users/presentation/users-kakao.controller';
 import { UsersService } from 'src/api/public/users/application/users.service';
 import { UserMessageFactory } from 'src/api/public/users/presentation/user-message.factory';
 import { CommonMessageFactory } from 'src/api/public/common/presentation/common-message.factory';
@@ -17,7 +17,7 @@ import { DepartmentMessageFactory } from 'src/api/public/departments/presentatio
 
 @Module({
   imports: [TypeOrmModule.forFeature([User]), CampusesModule, CollegesModule, DepartmentsModule],
-  controllers: [UsersController],
+  controllers: [UsersKakaoController],
   providers: [
     UsersService,
     UsersRepository,

--- a/services/api/app/test/cafeterias.e2e-spec.ts
+++ b/services/api/app/test/cafeterias.e2e-spec.ts
@@ -2,7 +2,7 @@ import { ForbiddenException, INestApplication, Module, ValidationPipe } from '@n
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { CafeteriasController } from 'src/api/public/cafeterias/presentation/cafeterias.controller';
+import { CafeteriasKakaoController } from 'src/api/public/cafeterias/presentation/cafeterias-kakao.controller';
 import { CafeteriasService } from 'src/api/public/cafeterias/application/cafeterias.service';
 import { KakaoAuthGuard } from 'src/api/public/users/presentation/guards/kakao-auth.guard';
 import { CurrentUserInterceptor } from 'src/api/public/users/presentation/interceptors/current-user.interceptor';
@@ -33,7 +33,7 @@ const mockUsersService = {
 };
 
 @Module({
-  controllers: [CafeteriasController],
+  controllers: [CafeteriasKakaoController],
   providers: [
     { provide: CafeteriasService, useValue: mockCafeteriasService },
     { provide: UsersService, useValue: mockUsersService },

--- a/services/api/app/test/notices.e2e-spec.ts
+++ b/services/api/app/test/notices.e2e-spec.ts
@@ -2,7 +2,7 @@ import { INestApplication, Module, ValidationPipe } from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { NoticesController } from 'src/api/public/notices/presentation/notices.controller';
+import { NoticesKakaoController } from 'src/api/public/notices/presentation/notices-kakao.controller';
 import { NoticesService } from 'src/api/public/notices/application/notices.service';
 import { KakaoAuthGuard } from 'src/api/public/users/presentation/guards/kakao-auth.guard';
 import { CurrentUserInterceptor } from 'src/api/public/users/presentation/interceptors/current-user.interceptor';
@@ -31,7 +31,7 @@ const mockUsersService = {
 };
 
 @Module({
-  controllers: [NoticesController],
+  controllers: [NoticesKakaoController],
   providers: [
     { provide: NoticesService, useValue: mockNoticesService },
     { provide: UsersService, useValue: mockUsersService },


### PR DESCRIPTION
## 📌 개요

- 카카오 챗봇 표현 계층의 제약과 상수를 application/infrastructure 계층에서 분리하고, 채널별 컨트롤러 책임을 명확히 정리했습니다.

## ✨ 작업 내용

- 카카오 block id, 리스트 카드 제한, 공지 캐러셀 제한, 캠퍼스 선택 sentinel 값을 카카오 presentation 전용 상수로 통합했습니다.
- 카카오 컨트롤러 파일명과 클래스명을 `*-kakao.controller` 형태로 변경해 native controller와 책임을 구분했습니다.
- 공지사항 조회 개수와 단과대학/학과 페이지 크기를 호출 채널에서 주입할 수 있도록 분리했습니다.
- 학식 조회에서 application 타입이 카카오 요청 DTO에 의존하지 않도록 식사 시간/상대 날짜 타입을 application 계층으로 이동했습니다.
- 사용자 프로필 결과를 구조화하고, `미등록` 등 카카오 표시 문자열은 메시지 팩토리에서 조합하도록 변경했습니다.
- 관련 서비스/메시지 팩토리 테스트를 추가하거나 수정해 변경된 책임 경계를 검증했습니다.

## 🔥 변경 이유

- 카카오 챗봇의 UI 제약(캐러셀 4개, 리스트 카드 5개, block extra sentinel)이 유스케이스와 저장소 계층에 섞이면 Native REST API 등 다른 채널 요구사항에 대응하기 어렵습니다.
- 조회 정책과 표현 정책을 분리해 기존 카카오 챗봇 동작은 유지하면서도, 추후 채널별 조회 개수나 응답 형식 변경에 더 안전하게 대응할 수 있도록 했습니다.

## 🧪 테스트

- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- `pnpm --dir services/api/app lint:check`
- `pnpm --dir services/api/app test`

## 🔗 관련 이슈

- 해당 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 프로필에서 캠퍼스, 대학, 학과 정보를 더 상세하게 제공합니다.
  * 공지사항 조회에서 카테고리별 항목 개수를 유연하게 설정할 수 있습니다.

* **Bug Fixes**
  * 페이징 처리 개선으로 페이지 번호가 1 미만일 때 자동 보정됩니다.

* **Refactor**
  * Kakao 플랫폼 최적화를 위해 내부 상수 및 설정값 구조를 개선했습니다.
  * 여러 서비스에서 페이지 크기 매개변수를 추가해 더 유연한 페이징을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->